### PR TITLE
Mrcd8 80 news content type

### DIFF
--- a/modules/mrc/mrc_news/config/install/core.entity_form_display.node.stanford_news_item.default.yml
+++ b/modules/mrc/mrc_news/config/install/core.entity_form_display.node.stanford_news_item.default.yml
@@ -1,0 +1,176 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.stanford_news_item.body
+    - field.field.node.stanford_news_item.field_s_news_attachment
+    - field.field.node.stanford_news_item.field_s_news_categories
+    - field.field.node.stanford_news_item.field_s_news_date
+    - field.field.node.stanford_news_item.field_s_news_featured
+    - field.field.node.stanford_news_item.field_s_news_image
+    - field.field.node.stanford_news_item.field_s_news_link
+    - field.field.node.stanford_news_item.field_s_news_meta_tags
+    - field.field.node.stanford_news_item.field_s_news_source
+    - image.style.thumbnail
+    - node.type.stanford_news_item
+  module:
+    - datetime
+    - field_group
+    - file
+    - image
+    - link
+    - metatag
+    - path
+    - text
+third_party_settings:
+  field_group:
+    group_s_news_external_info:
+      children:
+        - field_s_news_date
+        - field_s_news_source
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: false
+      label: 'Add/Edit External Article Information'
+    group_s_news_advanced:
+      children:
+        - field_s_news_categories
+        - field_s_news_featured
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: Advanced
+id: node.stanford_news_item.default
+targetEntityType: node
+bundle: stanford_news_item
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_s_news_attachment:
+    weight: 4
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  field_s_news_categories:
+    weight: 14
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_s_news_date:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_s_news_featured:
+    weight: 15
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_s_news_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  field_s_news_link:
+    weight: 5
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_s_news_meta_tags:
+    weight: 7
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_firehose
+    region: content
+  field_s_news_source:
+    weight: 11
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 11
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 13
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 12
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/mrc/mrc_news/config/install/core.entity_view_display.node.stanford_news_item.default.yml
+++ b/modules/mrc/mrc_news/config/install/core.entity_view_display.node.stanford_news_item.default.yml
@@ -1,0 +1,183 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.stanford_news_item.body
+    - field.field.node.stanford_news_item.field_s_news_attachment
+    - field.field.node.stanford_news_item.field_s_news_categories
+    - field.field.node.stanford_news_item.field_s_news_date
+    - field.field.node.stanford_news_item.field_s_news_featured
+    - field.field.node.stanford_news_item.field_s_news_image
+    - field.field.node.stanford_news_item.field_s_news_link
+    - field.field.node.stanford_news_item.field_s_news_meta_tags
+    - field.field.node.stanford_news_item.field_s_news_source
+    - node.type.stanford_news_item
+  module:
+    - datetime
+    - field_group
+    - file
+    - image
+    - link
+    - text
+    - user
+third_party_settings:
+  field_group:
+    group_s_postcard:
+      children:
+        - group_s_postcard_image
+        - group_s_postcard_content
+        - body
+        - field_s_news_link
+        - field_s_news_attachment
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: ''
+        element: div
+        show_label: false
+        label_element: h3
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Postcard
+    group_s_postcard_image:
+      children:
+        - field_s_news_image
+      parent_name: group_s_postcard
+      weight: 20
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: 'postcard-image group_s_postcard_image'
+        element: div
+        show_label: false
+        label_element: h3
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Postcard Image'
+    group_s_postcard_content:
+      children:
+        - group_descriptor_info
+      parent_name: group_s_postcard
+      weight: 21
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: postcard-content
+        element: div
+        show_label: false
+        label_element: h3
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Postcard Content'
+    group_descriptor_info:
+      children:
+        - field_s_news_date
+        - field_s_news_source
+        - group_s_news_postedin
+      parent_name: group_s_postcard_content
+      weight: 1
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: descriptor
+        element: div
+        show_label: false
+        label_element: h3
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Group Descriptor Info'
+    group_s_news_postedin:
+      children:
+        - field_s_news_categories
+      parent_name: group_descriptor_info
+      weight: 6
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: descriptor
+        element: div
+        show_label: false
+        label_element: h3
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Posted In'
+id: node.stanford_news_item.default
+targetEntityType: node
+bundle: stanford_news_item
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 22
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_s_news_attachment:
+    weight: 24
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: file_default
+    region: content
+  field_s_news_categories:
+    weight: 9
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_s_news_date:
+    weight: 4
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_s_news_image:
+    weight: 3
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_s_news_link:
+    weight: 23
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_s_news_source:
+    weight: 5
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden:
+  field_s_news_featured: true
+  field_s_news_meta_tags: true
+  links: true

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.body.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.body.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.stanford_news_item
+  module:
+    - text
+id: node.stanford_news_item.body
+field_name: body
+entity_type: node
+bundle: stanford_news_item
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_attachment.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_attachment.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_attachment
+    - node.type.stanford_news_item
+  module:
+    - file
+id: node.stanford_news_item.field_s_news_attachment
+field_name: field_s_news_attachment
+entity_type: node
+bundle: stanford_news_item
+label: File
+description: 'Upload file attachments associated with this news item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'txt pdf doc docx ppt pptx'
+  max_filesize: ''
+  description_field: true
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_categories.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_categories.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_categories
+    - node.type.stanford_news_item
+    - taxonomy.vocabulary.news_categories
+id: node.stanford_news_item.field_s_news_categories
+field_name: field_s_news_categories
+entity_type: node
+bundle: stanford_news_item
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      news_categories: news_categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_date.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_date.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_date
+    - node.type.stanford_news_item
+  module:
+    - datetime
+id: node.stanford_news_item.field_s_news_date
+field_name: field_s_news_date
+entity_type: node
+bundle: stanford_news_item
+label: Date
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_featured.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_featured.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_featured
+    - node.type.stanford_news_item
+id: node.stanford_news_item.field_s_news_featured
+field_name: field_s_news_featured
+entity_type: node
+bundle: stanford_news_item
+label: Featured
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_image.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_image.yml
@@ -23,7 +23,7 @@ settings:
   max_resolution: ''
   min_resolution: ''
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_image.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_image
+    - node.type.stanford_news_item
+  module:
+    - image
+id: node.stanford_news_item.field_s_news_image
+field_name: field_s_news_image
+entity_type: node
+bundle: stanford_news_item
+label: 'News Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_link.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_link
+    - node.type.stanford_news_item
+  module:
+    - link
+id: node.stanford_news_item.field_s_news_link
+field_name: field_s_news_link
+entity_type: node
+bundle: stanford_news_item
+label: 'External Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_meta_tags.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_meta_tags.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_meta_tags
+    - node.type.stanford_news_item
+  module:
+    - metatag
+id: node.stanford_news_item.field_s_news_meta_tags
+field_name: field_s_news_meta_tags
+entity_type: node
+bundle: stanford_news_item
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 'a:0:{}'
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_source.yml
+++ b/modules/mrc/mrc_news/config/install/field.field.node.stanford_news_item.field_s_news_source.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_news_source
+    - node.type.stanford_news_item
+  module:
+    - link
+id: node.stanford_news_item.field_s_news_source
+field_name: field_s_news_source
+entity_type: node
+bundle: stanford_news_item
+label: Source
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_attachment.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_attachment.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_s_news_attachment
+field_name: field_s_news_attachment
+entity_type: node
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_categories.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_categories.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_s_news_categories
+field_name: field_s_news_categories
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_date.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_s_news_date
+field_name: field_s_news_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_featured.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_featured.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_s_news_featured
+field_name: field_s_news_featured
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_image.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_s_news_image
+field_name: field_s_news_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_link.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_s_news_link
+field_name: field_s_news_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_meta_tags.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_meta_tags.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_s_news_meta_tags
+field_name: field_s_news_meta_tags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_source.yml
+++ b/modules/mrc/mrc_news/config/install/field.storage.node.field_s_news_source.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_s_news_source
+field_name: field_s_news_source
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc/mrc_news/config/install/node.type.stanford_news_item.yml
+++ b/modules/mrc/mrc_news/config/install/node.type.stanford_news_item.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'News Item'
+type: stanford_news_item
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/modules/mrc/mrc_news/config/install/pathauto.pattern.mrc_news.yml
+++ b/modules/mrc/mrc_news/config/install/pathauto.pattern.mrc_news.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: mrc_news
+label: 'MRC News'
+type: 'canonical_entities:node'
+pattern: 'news/[node:title]'
+selection_criteria:
+  c9410459-e8b0-4492-9919-9b2c3c9330aa:
+    id: node_type
+    bundles:
+      stanford_news_item: stanford_news_item
+    negate: false
+    context_mapping:
+      node: node
+    uuid: c9410459-e8b0-4492-9919-9b2c3c9330aa
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/modules/mrc/mrc_news/config/install/taxonomy.vocabulary.news_categories.yml
+++ b/modules/mrc/mrc_news/config/install/taxonomy.vocabulary.news_categories.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'News Categories'
+vid: news_categories
+description: 'Categories for news items'
+hierarchy: 0
+weight: 0

--- a/modules/mrc/mrc_news/mrc_news.info.yml
+++ b/modules/mrc/mrc_news/mrc_news.info.yml
@@ -5,4 +5,12 @@ core: 8.x
 package: Stanford
 version: 8.x-1.0-dev
 dependencies:
-
+  - file
+  - image
+  - link
+  - node
+  - taxonomy
+  - text
+  - pathauto
+  - datetime_range
+  - allowed_formats

--- a/modules/mrc/mrc_news/mrc_news.info.yml
+++ b/modules/mrc/mrc_news/mrc_news.info.yml
@@ -14,3 +14,4 @@ dependencies:
   - pathauto
   - datetime_range
   - allowed_formats
+  - metatag

--- a/modules/mrc/mrc_news/mrc_news.info.yml
+++ b/modules/mrc/mrc_news/mrc_news.info.yml
@@ -1,0 +1,8 @@
+name: 'MRC News'
+type: module
+description: 'MRC news items and views.'
+core: 8.x
+package: Stanford
+version: 8.x-1.0-dev
+dependencies:
+


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding News content type to MRC

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test

1. Use MRCD8-80-news-content-type in mrc_blt for provisioning
1. Check out this branch and install MRC News conent type
2. Review that content type and dependencies are created(taxonomy, pathauto).

# Affected Projects or Products
- MRC

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/MRCD8-80
- https://github.com/SU-HSDO/mrc_blt/pull/2