### PR TITLE
Mrcd8 168 media inline form

### DIFF
--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -16,6 +16,9 @@ settings:
           items:
             - Bold
             - Italic
+            - Outdent
+            - Indent
+            - Table
         -
           name: Links
           items:
@@ -32,9 +35,19 @@ settings:
             - Blockquote
             - media_browser
         -
+          name: Styles
+          items:
+            - Format
+            - Styles
+        -
           name: Tools
           items:
+            - RemoveFormat
+            - PasteFromWord
             - Source
+            - Undo
+            - Redo
+            - Maximize
   plugins:
     drupallink:
       linkit_enabled: true
@@ -42,7 +55,7 @@ settings:
     language:
       language_list: un
     stylescombo:
-      styles: ''
+      styles: "a.btn|Button\r\na.some-class|My Class"
 image_upload:
   status: false
   scheme: public

--- a/modules/mrc_media/config/install/core.entity_form_display.media.video.default.yml
+++ b/modules/mrc_media/config/install/core.entity_form_display.media.video.default.yml
@@ -5,53 +5,28 @@ dependencies:
     - field.field.media.video.field_media_video_embed_field
     - media.type.video
   module:
-    - path
     - video_embed_field
 id: media.video.default
 targetEntityType: media
 bundle: video
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_media_video_embed_field:
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield
-    weight: 101
+    weight: 1
     region: content
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 100
-    region: content
-    third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    region: content
-    third_party_settings: {  }
-hidden: {  }
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/modules/mrc_media/config/install/core.entity_view_display.media.image.thumbnail.yml
+++ b/modules/mrc_media/config/install/core.entity_view_display.media.image.thumbnail.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.thumbnail
+    - field.field.media.image.field_media_image
+    - image.style.thumbnail
+    - media.type.image
+  module:
+    - image
+_core:
+  default_config_hash: Z-q-BsMo4WG234VrI7ezloYiI3MjbnKTZ_7YldIoo40
+id: media.image.thumbnail
+targetEntityType: media
+bundle: image
+mode: thumbnail
+content:
+  field_media_image:
+    label: hidden
+    settings:
+      image_style: thumbnail
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    weight: 0
+    region: content
+hidden:
+  created: true
+  thumbnail: true
+  uid: true

--- a/modules/mrc_media/config/install/core.entity_view_mode.media.thumbnail.yml
+++ b/modules/mrc_media/config/install/core.entity_view_mode.media.thumbnail.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.thumbnail
+label: Thumbnail
+targetEntityType: media
+cache: true

--- a/modules/mrc_media/config/install/views.view.media_entity_browser.yml
+++ b/modules/mrc_media/config/install/views.view.media_entity_browser.yml
@@ -1,10 +1,14 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.media.thumbnail
   module:
     - entity_browser
     - media
     - user
+_core:
+  default_config_hash: EjsYOkTuE8g6c-8IvWifRVQpPSCbtnPxMjolu4bikfE
 id: media_entity_browser
 label: 'Media Entity Browser'
 module: views
@@ -245,7 +249,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          view_mode: default
+          view_mode: thumbnail
           entity_type: media
           plugin_id: rendered_entity
       filters:
@@ -377,8 +381,9 @@ display:
         - user.permissions
       tags:
         - 'config:core.entity_view_display.media.file.default'
-        - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'
+        - 'config:core.entity_view_display.media.image.default'
   media_browser:
     display_plugin: entity_browser
     id: media_browser
@@ -398,3 +403,4 @@ display:
         - 'config:core.entity_view_display.media.file.default'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'

--- a/modules/mrc_media/css/mrc_media.browser.css
+++ b/modules/mrc_media/css/mrc_media.browser.css
@@ -3,7 +3,9 @@
 div[data-drupal-selector="edit-actions"] input:disabled {
   display: none;
 }
-img {
-  height: 20px;
-  width: 20px;
+
+#entity .field--name-revision-log-message,
+#entity input[value="Remove"],
+div[data-drupal-selector="edit-actions"] input:disabled {
+  display: none;
 }

--- a/modules/mrc_media/css/mrc_media.browser.css
+++ b/modules/mrc_media/css/mrc_media.browser.css
@@ -1,0 +1,9 @@
+#entities .field--name-revision-log-message,
+#entities input[value="Remove"],
+div[data-drupal-selector="edit-actions"] input:disabled {
+  display: none;
+}
+img {
+  height: 20px;
+  width: 20px;
+}

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -62,4 +62,8 @@ function mrc_media_install() {
  */
 function mrc_media_update_8001() {
   mrc_media_install();
+
+  module_load_install('stanford_mrc');
+  $path = drupal_get_path('module', 'mrc_media') . '/config/install';
+  stanford_mrc_update_configs(TRUE, 'all', $path);
 }

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * mrc_media.install
+ */
+
+/**
+ * Implements hook_install().
+ */
+function mrc_media_install() {
+  $config_factory = \Drupal::configFactory();
+
+  // Media Image form.
+  $config = $config_factory->getEditable('core.entity_form_display.media.image.default');
+  $data = $config->getRawData();
+  foreach (['created', 'path', 'uid', 'status'] as $hide_field) {
+    unset($data['content'][$hide_field]);
+    $data['hidden'][$hide_field] = TRUE;
+  }
+  $config->setData($data);
+  $config->save(TRUE);
+
+  // Media Image display.
+  $config = $config_factory->getEditable('core.entity_view_display.media.image.default');
+  $data = $config->getRawData();
+  $data['content']['field_media_image']['label'] = 'hidden';
+  $data['content']['field_media_image']['settings']['image_style'] = '';
+  $data['content']['field_media_image']['settings']['image_link'] = '';
+  $config->setData($data);
+  $config->save(TRUE);
+
+  // Media Image image field.
+  $config = $config_factory->getEditable('field.field.media.image.field_media_image');
+  $data = $config->getRawData();
+  $data['settings']['alt_field_required'] = FALSE;
+  $data['settings']['file_directory'] = 'media';
+  $config->setData($data);
+  $config->save(TRUE);
+
+  // Media File form.
+  $config = $config_factory->getEditable('core.entity_form_display.media.file.default');
+  $data = $config->getRawData();
+  foreach (['created', 'path', 'uid', 'status'] as $hide_field) {
+    unset($data['content'][$hide_field]);
+    $data['hidden'][$hide_field] = TRUE;
+  }
+  $config->setData($data);
+  $config->save(TRUE);
+
+  // Media File display.
+  $config = $config_factory->getEditable('core.entity_view_display.media.file.default');
+  $data = $config->getRawData();
+  $data['content']['field_media_file']['label'] = 'hidden';
+  $config->setData($data);
+  $config->save(TRUE);
+
+}
+
+/**
+ * Run install function to edit core media bundles.
+ */
+function mrc_media_update_8001() {
+  mrc_media_install();
+}

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -5,6 +5,9 @@
  * mrc_media.install
  */
 
+use Drupal\embed\Entity\EmbedButton;
+use Drupal\file\Entity\File;
+
 /**
  * Implements hook_install().
  */
@@ -55,6 +58,25 @@ function mrc_media_install() {
   $config->setData($data);
   $config->save(TRUE);
 
+  mrc_media_add_embed_button();
+}
+
+/**
+ * Edits the media browser button to have an icon.
+ */
+function mrc_media_add_embed_button() {
+  $icon = \Drupal::moduleHandler()->getModule('mrc_media')->getPath() . '/img/media.png';
+  $fs = \Drupal::service('file_system');
+  $destination = file_unmanaged_copy($icon, 'public://media/' . $fs->basename($icon));
+
+  if ($destination) {
+    $file = File::create(['uri' => $destination]);
+    $file->save();
+
+    EmbedButton::load('media_browser')
+      ->set('icon_uuid', $file->uuid())
+      ->save();
+  }
 }
 
 /**
@@ -66,4 +88,11 @@ function mrc_media_update_8001() {
   module_load_install('stanford_mrc');
   $path = drupal_get_path('module', 'mrc_media') . '/config/install';
   stanford_mrc_update_configs(TRUE, 'all', $path);
+}
+
+/**
+ * Sets the media browser embed button icon.
+ */
+function mrc_media_update_8002() {
+  mrc_media_add_embed_button();
 }

--- a/modules/mrc_media/mrc_media.libraries.yml
+++ b/modules/mrc_media/mrc_media.libraries.yml
@@ -10,3 +10,9 @@ mrc_media.autocomplete:
     - core/drupal.ajax
     - core/jquery.ui.autocomplete
     - core/underscore
+
+mrc_media.browser:
+  version: VERSION
+  css:
+    component:
+      css/mrc_media.browser.css: {}

--- a/modules/mrc_media/src/Form/EntityEmbedDialog.php
+++ b/modules/mrc_media/src/Form/EntityEmbedDialog.php
@@ -180,6 +180,20 @@ class EntityEmbedDialog implements ContainerInjectionInterface {
    *   Form state object.
    */
   public static function formSubmit(array &$form, FormStateInterface $form_state) {
+    $settings = $form_state->getValue([
+      'attributes',
+      'data-entity-embed-display-settings',
+    ]);
+    $settings = array_filter($settings);
+    // Clean up the display settings, but we still want at least an empty alt
+    // text. This also helps prevent an empty array which converts to an empty
+    // string. An empty string breaks the render portion.
+    $settings['alt_text'] = isset($settings['alt_text']) ? $settings['alt_text'] : '';
+    $form_state->setValue([
+      'attributes',
+      'data-entity-embed-display-settings',
+    ], $settings);
+
     $linkit_key = [
       'attributes',
       'data-entity-embed-display-settings',

--- a/modules/mrc_media/src/Form/EntityEmbedDialog.php
+++ b/modules/mrc_media/src/Form/EntityEmbedDialog.php
@@ -68,16 +68,17 @@ class EntityEmbedDialog implements ContainerInjectionInterface {
   public function alterForm(array &$form, FormStateInterface $form_state) {
     $entity = $form_state->get('entity');
 
-//    $form['entity'] = [
-//      '#type' => 'inline_entity_form',
-//      '#entity_type' => $entity->getEntityTypeId(),
-//      '#bundle' => $entity->bundle(),
-//      '#default_value' => $entity,
-//      '#form_mode' => 'media_browser',
-//      '#prefix' => '<div id="entities">',
-//      '#suffix' => '</div>',
-//      '#weight' => 99,
-//    ];
+    // @todo: decide if we need this.
+    //    $form['entity'] = [
+    //      '#type' => 'inline_entity_form',
+    //      '#entity_type' => $entity->getEntityTypeId(),
+    //      '#bundle' => $entity->bundle(),
+    //      '#default_value' => $entity,
+    //      '#form_mode' => 'media_browser',
+    //      '#prefix' => '<div id="entities">',
+    //      '#suffix' => '</div>',
+    //      '#weight' => 99,
+    //    ];
 
     switch ($entity->bundle()) {
       case 'image':

--- a/modules/mrc_media/src/Form/EntityEmbedDialog.php
+++ b/modules/mrc_media/src/Form/EntityEmbedDialog.php
@@ -68,6 +68,17 @@ class EntityEmbedDialog implements ContainerInjectionInterface {
   public function alterForm(array &$form, FormStateInterface $form_state) {
     $entity = $form_state->get('entity');
 
+//    $form['entity'] = [
+//      '#type' => 'inline_entity_form',
+//      '#entity_type' => $entity->getEntityTypeId(),
+//      '#bundle' => $entity->bundle(),
+//      '#default_value' => $entity,
+//      '#form_mode' => 'media_browser',
+//      '#prefix' => '<div id="entities">',
+//      '#suffix' => '</div>',
+//      '#weight' => 99,
+//    ];
+
     switch ($entity->bundle()) {
       case 'image':
         $this->entityEmbedImage($form, $form_state);
@@ -328,6 +339,9 @@ class EntityEmbedDialog implements ContainerInjectionInterface {
 
     if (!empty($render['#display_settings']['image_style'])) {
       $render[$source_field][0]['#image_style'] = $render['#display_settings']['image_style'];
+    }
+    else {
+      unset($render[$source_field][0]['#image_style']);
     }
   }
 

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
@@ -204,9 +204,14 @@ class DropzoneUpload extends WidgetBase {
   }
 
   /**
-   * @param array $original_form
+   * Add the inline entity form after the files have been uploaded.
+   *
+   * @param array $form
+   *   Original form from getFrom().
    * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
    * @param array $additional_widget_parameters
+   *   Additional parameters we dont need.
    *
    * @return array
    */
@@ -318,6 +323,8 @@ class DropzoneUpload extends WidgetBase {
    * {@inheritdoc}
    */
   public function submit(array &$element, array &$form, FormStateInterface $form_state) {
+    parent::submit($element, $form, $form_state);
+
     $children = Element::children($element['entities']);
     foreach ($children as $child) {
       $entity_form = $element['entities'][$child];
@@ -333,7 +340,6 @@ class DropzoneUpload extends WidgetBase {
 
     $media_entities = $this->prepareEntities($form, $form_state);
 
-    $this->selectEntities($media_entities, $form_state);
     $this->clearFormValues($element, $form_state);
   }
 

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
@@ -340,6 +340,7 @@ class DropzoneUpload extends WidgetBase {
 
     $media_entities = $this->prepareEntities($form, $form_state);
 
+    $this->selectEntities($media_entities, $form_state);
     $this->clearFormValues($element, $form_state);
   }
 

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
@@ -3,6 +3,8 @@
 namespace Drupal\mrc_media\Plugin\EntityBrowser\Widget;
 
 use Drupal\Component\Utility\Bytes;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -12,7 +14,10 @@ use Drupal\entity_browser\WidgetValidationManager;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\file\Entity\File;
+use Drupal\image\Plugin\Field\FieldWidget\ImageWidget;
+use Drupal\inline_entity_form\ElementSubmit;
 use Drupal\media\Entity\Media;
+use Drupal\media\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -150,7 +155,12 @@ class DropzoneUpload extends WidgetBase {
     $file_entities = [];
     $media_entities = [];
 
-    foreach ($this->getFiles($form, $form_state) as $file) {
+    if ($form_state->get(['dropzonejs', $this->uuid(), 'media'])) {
+      return $form_state->get(['dropzonejs', $this->uuid(), 'media']);
+    }
+
+    $files = $this->getFiles($form, $form_state);
+    foreach ($files as $file) {
       if ($file instanceof File) {
         $file_entities[] = $file;
         $media_type = $this->getExtensionBundle(pathinfo($file->getFileUri(), PATHINFO_EXTENSION));
@@ -166,7 +176,7 @@ class DropzoneUpload extends WidgetBase {
           ]);
       }
     }
-
+    $form_state->set(['dropzonejs', $this->uuid(), 'media'], $media_entities);
     return $media_entities;
   }
 
@@ -194,7 +204,71 @@ class DropzoneUpload extends WidgetBase {
     $form['#attached']['library'][] = 'dropzonejs_eb_widget/common';
     $original_form['#attributes']['class'][] = 'dropzonejs-disable-submit';
 
+    $this->getEntityForm($form, $form_state, $additional_widget_parameters);
     return $form;
+  }
+
+  /**
+   * @param array $original_form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * @param array $additional_widget_parameters
+   *
+   * @return array
+   */
+  public function getEntityForm(array &$form, FormStateInterface $form_state, array $additional_widget_parameters) {
+
+    if (isset($form['actions'])) {
+      $form['actions']['#weight'] = 100;
+    }
+
+    $form['entities'] = [
+      '#prefix' => '<div id="entities">',
+      '#suffix' => '</div>',
+      '#weight' => 99,
+    ];
+
+    $media_entities = $this->prepareEntities($form, $form_state);
+
+    if (empty($media_entities)) {
+      $form['entities']['#markup'] = NULL;
+      return $form;
+    }
+
+    foreach ($media_entities as $entity) {
+      $form['entities'][$entity->id()] = [
+        '#type' => 'inline_entity_form',
+        '#entity_type' => $entity->getEntityTypeId(),
+        '#bundle' => $entity->bundle(),
+        '#default_value' => $entity,
+        '#form_mode' => 'media_browser',
+      ];
+    }
+
+    // Without this, IEF won't know where to hook into the widget. Don't pass
+    // $original_form as the second argument to addCallback(), because it's not
+    // just the entity browser part of the form, not the actual complete form.
+    ElementSubmit::addCallback($form['actions']['submit'], $form_state->getCompleteForm());
+
+    $form['#attached']['library'][] = 'mrc_media/mrc_media.browser';
+    return $form;
+  }
+
+  /**
+   * Returns the bundles that this widget may use.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   *
+   * @return string[]
+   *   The bundles that this widget may use. If all bundles may be used, the
+   *   returned array will be empty.
+   */
+  protected function getAllowedBundles(FormStateInterface $form_state) {
+    return (array) $form_state->get([
+      'entity_browser',
+      'widget_context',
+      'target_bundles',
+    ]);
   }
 
   /**
@@ -223,8 +297,14 @@ class DropzoneUpload extends WidgetBase {
   /**
    * {@inheritdoc}
    */
-  public function submit(array &$element, array &$form, FormStateInterface $form_state) {
-    $media_entities = $this->prepareEntities($form, $form_state);;
+  public function validate(array &$form, FormStateInterface $form_state) {
+    parent::validate($form, $form_state);
+
+    // Any errors, don't save the entities yet.
+    if ($form_state::hasAnyErrors()) {
+      return;
+    }
+    $media_entities = $this->prepareEntities($form, $form_state);
 
     foreach ($media_entities as &$media_entity) {
       if ($media_entity instanceof Media) {
@@ -237,6 +317,26 @@ class DropzoneUpload extends WidgetBase {
         $media_entity->save();
       }
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submit(array &$element, array &$form, FormStateInterface $form_state) {
+    $children = Element::children($element['entities']);
+    foreach ($children as $child) {
+      $entity_form = $element['entities'][$child];
+
+      if (!isset($entity_form['#ief_element_submit'])) {
+        continue;
+      }
+
+      foreach ($entity_form['#ief_element_submit'] as $submit_function) {
+        call_user_func_array($submit_function, [&$entity_form, $form_state]);
+      }
+    }
+
+    $media_entities = $this->prepareEntities($form, $form_state);
 
     $this->selectEntities($media_entities, $form_state);
     $this->clearFormValues($element, $form_state);
@@ -309,7 +409,7 @@ class DropzoneUpload extends WidgetBase {
       }
     }
 
-    if ($form['widget']['upload']['#max_files']) {
+    if (!empty($form['widget']['upload']['#max_files']) && $form['widget']['upload']['#max_files']) {
       $files = array_slice($files, -$form['widget']['upload']['#max_files']);
     }
 

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/DropzoneUpload.php
@@ -3,8 +3,6 @@
 namespace Drupal\mrc_media\Plugin\EntityBrowser\Widget;
 
 use Drupal\Component\Utility\Bytes;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -14,13 +12,10 @@ use Drupal\entity_browser\WidgetValidationManager;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\file\Entity\File;
-use Drupal\image\Plugin\Field\FieldWidget\ImageWidget;
 use Drupal\inline_entity_form\ElementSubmit;
 use Drupal\media\Entity\Media;
-use Drupal\media\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * An Entity Browser widget for creating media entities from embed codes.

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
@@ -101,6 +101,7 @@ class EmbedCode extends WidgetBase {
         'callback' => [static::class, 'ajax'],
       ],
     ];
+    $form['#attached']['library'][] = 'mrc_media/mrc_media.browser';
     return $form;
   }
 

--- a/stanford_mrc.install
+++ b/stanford_mrc.install
@@ -133,3 +133,11 @@ function stanford_mrc_update_8002() {
   \Drupal::service('module_installer')->install(['mrc_media']);
   stanford_mrc_update_configs(TRUE, 'all');
 }
+
+/**
+ * Resets the text format..
+ */
+function stanford_mrc_update_8003() {
+  stanford_mrc_update_configs(TRUE, 'all');
+}
+


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provided inline entity form when uploading via wysiwyg
- Updated text format to add additional buttons and allow classes

# Needed By (Date)
- Nov 7th

# Urgency
- high

# Steps to Test

1. checkout branch
2. `blt sync:db`
3. `drush updb -y`
4. got to create/edit any content type
5. verify more buttons in the ckeditor toolbar
6. click the "media browser" button in the toolbar. It should look like a square picture with a hill
7. click the "upload media" tab at the top
8. drag and drop a document or image into the area.
9. click the "Select Media" button to submit
10. you should be prompted with more fields to add alt text to an image and allow you to change the title on the item. Note: this is admin title not the file name. Similar to a node title
11. after setting a name and/or alt text. click the "select Entities"
12. you should be brought to another screen to do 1 of 2 things depending on the file you uploaded. populate these appropriately.
  a. image should have image style, alt text, title text, and link fields
  b. Documents like pdfs should have a description text field.
13. click embed and save the content.
14. ensure the media item displays as expected with the appropriate image style, attributes, etc.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)