### PR TITLE
Mrcd8 163 multiple file upload

### DIFF
--- a/modules/mrc_events/js/mrc_events.admin.js
+++ b/modules/mrc_events/js/mrc_events.admin.js
@@ -4,7 +4,6 @@
   Drupal.behaviors.mrcEventsAdmin = {
     attach: function attach() {
       $('input.show-end-date[type="checkbox"]').each(function () {
-        console.log($(this).parent().prev());
         if ($(this).is(':checked')) {
           $(this).parent().prev().show().prev().show();
         }

--- a/modules/mrc_media/config/install/system.action.media_delete_actions.yml
+++ b/modules/mrc_media/config/install/system.action.media_delete_actions.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: media_delete_action
+label: 'Delete media'
+type: media
+plugin: media_delete_action
+configuration: {  }

--- a/modules/mrc_media/config/install/views.view.media_entity_browser.yml
+++ b/modules/mrc_media/config/install/views.view.media_entity_browser.yml
@@ -5,12 +5,14 @@ dependencies:
     - core.entity_view_mode.media.thumbnail
   module:
     - entity_browser
+    - entity_usage
     - media
+    - mrc_media
     - user
 _core:
-  default_config_hash: EjsYOkTuE8g6c-8IvWifRVQpPSCbtnPxMjolu4bikfE
+  default_config_hash: BguJSCOtcBFVOpgk701zbH3qvAfmKozRkOowj7SNKKA
 id: media_entity_browser
-label: 'Media Entity Browser'
+label: 'MRC Media'
 module: views
 description: ''
 tag: ''
@@ -27,9 +29,9 @@ display:
       access:
         type: perm
         options:
-          perm: 'view media'
+          perm: 'administer media'
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query
@@ -50,12 +52,17 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
-          items_per_page: 10
+          items_per_page: 25
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -64,9 +71,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          quantity: 9
       style:
         type: table
         options:
@@ -74,27 +79,29 @@ display:
           row_class: ''
           default_row_class: true
           override: true
-          sticky: false
+          sticky: true
           caption: ''
           summary: ''
           description: ''
           columns:
-            entity_browser_select: entity_browser_select
-            name: name
+            link: link
+            count: count
           info:
-            entity_browser_select:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: false
+            link:
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-          default: '-1'
+            count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: count
           empty_table: false
       row:
         type: fields
@@ -381,9 +388,10 @@ display:
         - user.permissions
       tags:
         - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.full'
-        - 'config:core.entity_view_display.media.image.default'
   media_browser:
     display_plugin: entity_browser
     id: media_browser
@@ -402,5 +410,892 @@ display:
       tags:
         - 'config:core.entity_view_display.media.file.default'
         - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'
+  use_detail:
+    display_plugin: page
+    id: use_detail
+    display_title: 'Media Usage Detail'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media/%mid
+      display_description: ''
+      fields:
+        link:
+          id: link
+          table: entity_usage
+          field: link
+          relationship: media_to_usage_entity
+          group_type: group
+          admin_label: ''
+          label: 'Referencing Item'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: entity_usage_link
+        count:
+          id: count
+          table: entity_usage
+          field: count
+          relationship: media_to_usage_entity
+          group_type: group
+          admin_label: ''
+          label: Uses
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+          plugin_id: numeric
+      defaults:
+        fields: false
+        arguments: false
+        relationships: false
+        header: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        title: false
+      arguments:
+        mid:
+          id: mid
+          table: media_field_data
+          field: mid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:media'
+            fail: 'not found'
+          validate_options:
+            operation: view
+            multiple: 0
+            bundles: {  }
+            access: false
+          break_phrase: false
+          not: false
+          entity_type: media
+          entity_field: mid
+          plugin_id: numeric
+      relationships:
+        media_to_usage_entity:
+          id: media_to_usage_entity
+          table: media
+          field: media_to_usage_entity
+          relationship: none
+          group_type: group
+          admin_label: 'Usage information (Media)'
+          required: false
+          entity_type: media
+          plugin_id: standard
+      header:
+        entity_media:
+          id: entity_media
+          table: views
+          field: entity_media
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          target: '{{ arguments.mid }}'
+          view_mode: thumbnail
+          bypass_access: false
+          plugin_id: entity
+      sorts: {  }
+      filters: {  }
+      filter_groups:
+        operator: AND
+        groups: {  }
+      title: 'Media Use'
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  use_list:
+    display_plugin: page
+    id: use_list
+    display_title: 'Media Usage List'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media
+      relationships:
+        media_to_usage_entity:
+          id: media_to_usage_entity
+          table: media
+          field: media_to_usage_entity
+          relationship: none
+          group_type: group
+          admin_label: 'Usage information (Media)'
+          required: false
+          entity_type: media
+          plugin_id: standard
+      defaults:
+        relationships: false
+        fields: false
+        group_by: false
+        sorts: false
+        title: false
+        filters: false
+        filter_groups: false
+      fields:
+        media_bulk_form:
+          id: media_bulk_form
+          table: media
+          field: media_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: media
+          plugin_id: media_bulk_form
+        mid:
+          id: mid
+          table: media_field_data
+          field: mid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: mid
+          plugin_id: field
+        rendered_entity:
+          id: rendered_entity
+          table: media
+          field: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Thumbnail
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: thumbnail
+          entity_type: media
+          plugin_id: rendered_entity
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Media Name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: media
+          plugin_id: field
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
+        uid:
+          id: uid
+          table: media_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
+        changed:
+          id: changed
+          table: media_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
+        count:
+          id: count
+          table: entity_usage
+          field: count
+          relationship: media_to_usage_entity
+          group_type: sum
+          admin_label: ''
+          label: 'Used In'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: '/admin/content/media/{{ mid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ' Places'
+          plugin_id: numeric
+        operations:
+          id: operations
+          table: media
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: media
+          plugin_id: entity_operations
+      group_by: true
+      display_description: ''
+      sorts: {  }
+      menu:
+        type: tab
+        title: Media
+        description: ''
+        expanded: false
+        parent: ''
+        weight: 0
+        context: '0'
+        menu_name: main
+      title: Media
+      filters:
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: bundle_op
+            label: 'Media Type'
+            description: ''
+            use_operator: false
+            operator: bundle_op
+            identifier: bundle
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.full'

--- a/modules/mrc_media/config/install/views.view.media_entity_browser.yml
+++ b/modules/mrc_media/config/install/views.view.media_entity_browser.yml
@@ -10,7 +10,7 @@ dependencies:
     - mrc_media
     - user
 _core:
-  default_config_hash: BguJSCOtcBFVOpgk701zbH3qvAfmKozRkOowj7SNKKA
+  default_config_hash: X1XP3yBNnl0kHGDw1fc3DbVLqEOdZtkcHzvPAelUlLk
 id: media_entity_browser
 label: 'MRC Media'
 module: views
@@ -84,24 +84,30 @@ display:
           summary: ''
           description: ''
           columns:
-            link: link
-            count: count
+            entity_browser_select: entity_browser_select
+            name: name
+            rendered_entity: rendered_entity
           info:
-            link:
-              sortable: true
+            entity_browser_select:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            count:
-              sortable: true
-              default_sort_order: desc
+            rendered_entity:
+              sortable: false
+              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-          default: count
+          default: '-1'
           empty_table: false
       row:
         type: fields
@@ -538,6 +544,8 @@ display:
         filters: false
         filter_groups: false
         title: false
+        style: false
+        row: false
       arguments:
         mid:
           id: mid
@@ -610,6 +618,44 @@ display:
         operator: AND
         groups: {  }
       title: 'Media Use'
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            link: link
+            count: count
+          info:
+            link:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: count
+          empty_table: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
     cache_metadata:
       max-age: 0
       contexts:
@@ -645,6 +691,8 @@ display:
         title: false
         filters: false
         filter_groups: false
+        style: false
+        row: false
       fields:
         media_bulk_form:
           id: media_bulk_form
@@ -1285,6 +1333,96 @@ display:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            media_bulk_form: media_bulk_form
+            mid: mid
+            rendered_entity: rendered_entity
+            name: name
+            bundle: bundle
+            uid: uid
+            changed: changed
+            count: count
+            operations: operations
+          info:
+            media_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            mid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            rendered_entity:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
     cache_metadata:
       max-age: 0
       contexts:

--- a/modules/mrc_media/css/mrc_media.browser.css
+++ b/modules/mrc_media/css/mrc_media.browser.css
@@ -9,3 +9,11 @@ div[data-drupal-selector="edit-actions"] input:disabled {
 div[data-drupal-selector="edit-actions"] input:disabled {
   display: none;
 }
+
+#entities > div {
+  border-bottom: 1px solid #ccc;
+}
+
+#entities > div:last-child {
+  border-bottom: none;
+}

--- a/modules/mrc_media/js/mrc_media.embed.js
+++ b/modules/mrc_media/js/mrc_media.embed.js
@@ -1,0 +1,17 @@
+(function ($, window, Drupal) {
+  'use strict';
+
+  Drupal.behaviors.mrcMediaEmbed = {
+    attach: function attach() {
+
+      // Disable the submit button until after the ajax is done and the entity
+      // form is displayed.
+      if ($('#entity').html() == '') {
+        $('input.is-entity-browser-submit').prop('disabled', true);
+      }
+      else {
+        $('input.is-entity-browser-submit').prop('disabled', false);
+      }
+    }
+  };
+})(jQuery, window, Drupal);

--- a/modules/mrc_media/mrc_media.info.yml
+++ b/modules/mrc_media/mrc_media.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - entity_browser
   - entity_browser_entity_form
   - entity_embed
+  - entity_usage
   - inline_entity_form
   - linkit
   - media

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -77,7 +77,9 @@ function mrc_media_install() {
  * Edits the media browser button to have an icon.
  */
 function mrc_media_add_embed_button() {
-  $icon = \Drupal::moduleHandler()->getModule('mrc_media')->getPath() . '/img/media.png';
+  $icon = \Drupal::moduleHandler()
+      ->getModule('mrc_media')
+      ->getPath() . '/img/media.png';
   $fs = \Drupal::service('file_system');
 
   $directory = 'public://media/image/';
@@ -117,6 +119,13 @@ function mrc_media_update_8002() {
  * Replaces the admin media page with a view that has useage links.
  */
 function mrc_media_update_8003() {
+  $icon = 'public://media/image/media.png';
+  if (!file_exists($icon)) {
+    mrc_media_add_embed_button();
+  }
+
+  \Drupal::service('module_installer')->install(['entity_usage']);
+
   module_load_install('stanford_mrc');
   $path = drupal_get_path('module', 'mrc_media') . '/config/install';
   stanford_mrc_update_configs(TRUE, 'all', $path);

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -7,6 +7,7 @@
 
 use Drupal\embed\Entity\EmbedButton;
 use Drupal\file\Entity\File;
+use Drupal\views\Entity\View;
 
 /**
  * Implements hook_install().
@@ -65,6 +66,10 @@ function mrc_media_install() {
   $config->setData($data);
   $config->save(TRUE);
 
+  $view = View::load('media');
+  $view->disable();
+  $view->save();
+
   mrc_media_add_embed_button();
 }
 
@@ -106,4 +111,17 @@ function mrc_media_update_8001() {
  */
 function mrc_media_update_8002() {
   mrc_media_add_embed_button();
+}
+
+/**
+ * Replaces the admin media page with a view that has useage links.
+ */
+function mrc_media_update_8003() {
+  module_load_install('stanford_mrc');
+  $path = drupal_get_path('module', 'mrc_media') . '/config/install';
+  stanford_mrc_update_configs(TRUE, 'all', $path);
+
+  $view = View::load('media');
+  $view->disable();
+  $view->save();
 }

--- a/modules/mrc_media/mrc_media.install
+++ b/modules/mrc_media/mrc_media.install
@@ -37,7 +37,7 @@ function mrc_media_install() {
   $config = $config_factory->getEditable('field.field.media.image.field_media_image');
   $data = $config->getRawData();
   $data['settings']['alt_field_required'] = FALSE;
-  $data['settings']['file_directory'] = 'media';
+  $data['settings']['file_directory'] = 'media/image';
   $config->setData($data);
   $config->save(TRUE);
 
@@ -58,6 +58,13 @@ function mrc_media_install() {
   $config->setData($data);
   $config->save(TRUE);
 
+  // Media Image image field.
+  $config = $config_factory->getEditable('field.field.media.file.field_media_file');
+  $data = $config->getRawData();
+  $data['settings']['file_directory'] = 'media/file';
+  $config->setData($data);
+  $config->save(TRUE);
+
   mrc_media_add_embed_button();
 }
 
@@ -67,7 +74,11 @@ function mrc_media_install() {
 function mrc_media_add_embed_button() {
   $icon = \Drupal::moduleHandler()->getModule('mrc_media')->getPath() . '/img/media.png';
   $fs = \Drupal::service('file_system');
-  $destination = file_unmanaged_copy($icon, 'public://media/' . $fs->basename($icon));
+
+  $directory = 'public://media/image/';
+  file_prepare_directory($directory, FILE_CREATE_DIRECTORY);
+
+  $destination = file_unmanaged_copy($icon, $directory . $fs->basename($icon));
 
   if ($destination) {
     $file = File::create(['uri' => $destination]);

--- a/modules/mrc_media/mrc_media.libraries.yml
+++ b/modules/mrc_media/mrc_media.libraries.yml
@@ -16,3 +16,10 @@ mrc_media.browser:
   css:
     component:
       css/mrc_media.browser.css: {}
+
+mrc_media.embed:
+  version: VERSION
+  js:
+    js/mrc_media.embed.js: {}
+  dependencies:
+    - core/jquery

--- a/modules/mrc_media/mrc_media.links.action.yml
+++ b/modules/mrc_media/mrc_media.links.action.yml
@@ -1,0 +1,5 @@
+mrc_media.bulk_upload:
+  route_name: entity.media.add_page
+  title: 'Add media'
+  appears_on:
+    - view.media_entity_browser.use_list

--- a/modules/mrc_media/mrc_media.module
+++ b/modules/mrc_media/mrc_media.module
@@ -10,7 +10,6 @@ use Drupal\editor\Entity\Editor;
 use Drupal\mrc_media\Form\EntityEmbedDialog;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\file\Entity\File;
-use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 
 /**
  * Implements hook_field_widget_form_alter().

--- a/modules/mrc_media/mrc_media.module
+++ b/modules/mrc_media/mrc_media.module
@@ -10,6 +10,7 @@ use Drupal\editor\Entity\Editor;
 use Drupal\mrc_media\Form\EntityEmbedDialog;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\file\Entity\File;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 
 /**
  * Implements hook_field_widget_form_alter().
@@ -121,4 +122,28 @@ function mrc_media_theme_registry_alter(&$theme_registry) {
 function mrc_media_entity_embed_alter(array &$build, EntityInterface $entity, array &$context) {
   $build['entity']['#display_settings'] = $context['data-entity-embed-display-settings'];
   $build['entity']['#pre_render'][] = [EntityEmbedDialog::class, 'preRender'];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function mrc_media_preprocess_media(&$variables) {
+  /** @var \Drupal\media\Entity\MediaType $media_type */
+  $media_type = \Drupal::entityTypeManager()->getStorage('media_type')
+    ->load($variables['media']->bundle());
+  $source_field = $media_type->getSource()
+    ->getConfiguration()['source_field'];
+
+  // We have to disable cache on media entities to allow wysiwyg references
+  // with different settings for each. Maybe theres a better way to cache it
+  // based on the configured settings.
+  // @todo: enable cache but cache per setting.
+  $variables['content'][$source_field]['#cache']['max-age'] = 0;
+  $variables['content'][$source_field]['0']['#cache']['max-age'] = 0;
+
+  // If the file media doesn't have a description, set the media name as the
+  // description. This should mostly be needed for the entity view page.
+  if ($variables['media']->bundle() == 'file' && empty($variables['content'][$source_field]['0']['#description'])) {
+    $variables['content'][$source_field]['0']['#description'] = $variables['name'];
+  }
 }

--- a/modules/mrc_media/mrc_media.routing.yml
+++ b/modules/mrc_media/mrc_media.routing.yml
@@ -1,0 +1,9 @@
+mrc_media.bulk_upload:
+  path: '/media/add/bulk'
+  defaults:
+    _form: '\Drupal\mrc_media\Form\BulkUpload'
+    _title: 'Bulk Upload'
+  requirements:
+    _permission: 'access content'
+  options:
+    _admin_route: TRUE

--- a/modules/mrc_media/mrc_media.routing.yml
+++ b/modules/mrc_media/mrc_media.routing.yml
@@ -1,9 +1,16 @@
 mrc_media.bulk_upload:
-  path: '/media/add/bulk'
+  path: '/admin/content/media/add/bulk'
   defaults:
     _form: '\Drupal\mrc_media\Form\BulkUpload'
     _title: 'Bulk Upload'
   requirements:
-    _permission: 'access content'
+    _permission: 'administer media'
   options:
     _admin_route: TRUE
+
+media.multiple_delete_confirm:
+  path: '/admin/content/media/bulk-delete'
+  defaults:
+    _form: '\Drupal\mrc_media\Form\DeleteMultiple'
+  requirements:
+    _permission: 'administer nodes'

--- a/modules/mrc_media/mrc_media.services.yml
+++ b/modules/mrc_media/mrc_media.services.yml
@@ -1,0 +1,9 @@
+services:
+  mrc_media.route_subscriber:
+    class: Drupal\mrc_media\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  mrc_media.bundle_suggestion:
+    class: '\Drupal\mrc_media\BundleSuggestion'
+    arguments:
+      - '@entity_type.manager'

--- a/modules/mrc_media/mrc_media.views.inc
+++ b/modules/mrc_media/mrc_media.views.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * mrc_media.views.inc
+ */
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function mrc_media_views_data_alter(array &$data) {
+  $data['entity_usage']['link'] = [
+    'title' => t('Usage Link'),
+    'help' => t('Link to the referencing entity.'),
+    'field' => [
+      'id' => 'entity_usage_link',
+    ],
+  ];
+  $data['media']['media_bulk_form'] = [
+    'title' => t('Media operations bulk form'),
+    'help' => t('Add a form element that lets you run operations on multiple medias.'),
+    'field' => [
+      'id' => 'media_bulk_form',
+    ],
+  ];
+
+  return $data;
+}

--- a/modules/mrc_media/src/BundleSuggestion.php
+++ b/modules/mrc_media/src/BundleSuggestion.php
@@ -9,6 +9,9 @@ use Drupal\media\Entity\MediaType;
 
 class BundleSuggestion {
 
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
   private $entityTypeManager;
 
   /**
@@ -99,6 +102,15 @@ class BundleSuggestion {
     return $max_filesize;
   }
 
+  /**
+   * Get maximum file size for the media type.
+   *
+   * @param \Drupal\media\Entity\MediaType $media_type
+   *   The media type bundle to get file size for.
+   *
+   * @return int
+   *   The maximum file size.
+   */
   public function getMaxFileSizeBundle(MediaType $media_type) {
     $source_field = $media_type->getSource()
       ->getConfiguration()['source_field'];

--- a/modules/mrc_media/src/BundleSuggestion.php
+++ b/modules/mrc_media/src/BundleSuggestion.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\mrc_media;
+
+use Drupal\Component\Utility\Bytes;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\media\Entity\MediaType;
+
+class BundleSuggestion {
+
+  private $entityTypeManager;
+
+  /**
+   * MediaHelper constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManager $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Get the available extension the user can upload.
+   *
+   * @return string
+   *   All available extensions.
+   */
+  public function getAllExtensions() {
+    $media_types = $this->getMediaBundles();
+
+    $extensions = [];
+    /** @var \Drupal\media\Entity\MediaType $media_type */
+    foreach ($media_types as $media_type) {
+      $extensions[] = $this->getBundleExtensions($media_type);
+    }
+
+    return implode(' ', $extensions);
+  }
+
+  /**
+   * Get all allowed file extensions that can be uploaded for a media type.
+   *
+   * @param \Drupal\media\Entity\MediaType $media_type
+   *   Media type entity object.
+   *
+   * @return string
+   *   All file extensions for the given media type.
+   */
+  public function getBundleExtensions(MediaType $media_type) {
+    $source_field = $media_type->getSource()
+      ->getConfiguration()['source_field'];
+    if ($source_field) {
+      $field = FieldConfig::loadByName('media', $media_type->id(), $source_field);
+      return $field->getSetting('file_extensions') ?: '';
+    }
+    return '';
+  }
+
+  /**
+   * Load the media type from the file uri.
+   *
+   * @param string $uri
+   *   The file uri.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   Media type bundle if one matches.
+   */
+  public function getBundleFromFile($uri) {
+    $extension = pathinfo($uri, PATHINFO_EXTENSION);
+    foreach ($this->getMediaBundles() as $media_type) {
+      if (strpos($this->getBundleExtensions($media_type), $extension) !== FALSE) {
+        return $media_type;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the maximum file size for all media bundles.
+   *
+   * @return int
+   *   Maximum file size for all bundles.
+   */
+  public function getMaxFilesize() {
+    $max_filesize = Bytes::toInt(file_upload_max_size());
+    $media_types = $this->getMediaBundles();
+
+    foreach ($media_types as $media_type) {
+
+      if ($max = $this->getMaxFileSizeBundle($media_type)) {
+        if ($max > $max_filesize) {
+          $max_filesize = $max;
+        }
+      }
+    }
+
+    return $max_filesize;
+  }
+
+  public function getMaxFileSizeBundle(MediaType $media_type) {
+    $source_field = $media_type->getSource()
+      ->getConfiguration()['source_field'];
+
+    if ($source_field) {
+      $field = FieldConfig::loadByName('media', $media_type->id(), $source_field);
+      return Bytes::toInt($field->getSetting('max_filesize'));
+    }
+    return 0;
+  }
+
+  public function getMediaPath(MediaType $media_type) {
+    return 'public://';
+  }
+
+  /**
+   * Get all or some media bundles.
+   *
+   * @param array $bundles
+   *   Optionally specifiy which media bundles to load.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   Keyed array of all media types.
+   */
+  private function getMediaBundles($bundles = []) {
+    return $this->entityTypeManager->getStorage('media_type')
+      ->loadMultiple($bundles ?: NULL);
+  }
+
+}

--- a/modules/mrc_media/src/Controller/MediaAdd.php
+++ b/modules/mrc_media/src/Controller/MediaAdd.php
@@ -12,9 +12,9 @@ class MediaAdd extends EntityController {
     $page = parent::addPage($entity_type_id);
 
     $url = new Url('mrc_media.bulk_upload');
-    unset($page['#bundles']['file'], $page['#bundles']['image']);;
+    unset($page['#bundles']['image']);;
 
-    $page['#bundles']['bulk'] = [
+    $page['#bundles']['file'] = [
       'label' => $this->t('Bulk Upload'),
       'description' => $this->t('Upload multiple files/images at once'),
       'add_link' => new Link($this->t('Bulk Upload'), $url),

--- a/modules/mrc_media/src/Controller/MediaAdd.php
+++ b/modules/mrc_media/src/Controller/MediaAdd.php
@@ -3,23 +3,73 @@
 namespace Drupal\mrc_media\Controller;
 
 use Drupal\Core\Entity\Controller\EntityController;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
+use Drupal\mrc_media\BundleSuggestion;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MediaAdd extends EntityController {
 
+  /**
+   * @var \Drupal\mrc_media\BundleSuggestion
+   */
+  protected $bundleSuggestion;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity.repository'),
+      $container->get('renderer'),
+      $container->get('string_translation'),
+      $container->get('url_generator'),
+      $container->get('mrc_media.bundle_suggestion')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityRepositoryInterface $entity_repository, RendererInterface $renderer, TranslationInterface $string_translation, UrlGeneratorInterface $url_generator, BundleSuggestion $bundle_suggestion) {
+    parent::__construct($entity_type_manager, $entity_type_bundle_info, $entity_repository, $renderer, $string_translation, $url_generator);
+    $this->bundleSuggestion = $bundle_suggestion;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addPage($entity_type_id) {
     $page = parent::addPage($entity_type_id);
+    $bulk_bundles = [];
 
+    foreach ($this->bundleSuggestion->getUploadBundles() as $media_type) {
+      unset($page['#bundles'][$media_type->id()]);
+      $bulk_bundles[] = $media_type->label();
+    }
+
+    // No media bundles that allow upload.
+    if (empty($bulk_bundles)) {
+      return $page;
+    }
+
+    // Add a bulk upload for all bundles with upload ability.
     $url = new Url('mrc_media.bulk_upload');
-    unset($page['#bundles']['image']);;
-
-    $page['#bundles']['file'] = [
+    $page['#bundles']['bulk'] = [
       'label' => $this->t('Bulk Upload'),
-      'description' => $this->t('Upload multiple files/images at once'),
+      'description' => $this->t('Create %bundles.', ['%bundles' => implode(', ', $bulk_bundles)]),
       'add_link' => new Link($this->t('Bulk Upload'), $url),
     ];
 
     return $page;
   }
+
 }

--- a/modules/mrc_media/src/Controller/MediaAdd.php
+++ b/modules/mrc_media/src/Controller/MediaAdd.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\mrc_media\Controller;
+
+use Drupal\Core\Entity\Controller\EntityController;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+
+class MediaAdd extends EntityController {
+
+  public function addPage($entity_type_id) {
+    $page = parent::addPage($entity_type_id);
+
+    $url = new Url('mrc_media.bulk_upload');
+    unset($page['#bundles']['file'], $page['#bundles']['image']);;
+
+    $page['#bundles']['bulk'] = [
+      'label' => $this->t('Bulk Upload'),
+      'description' => $this->t('Upload multiple files/images at once'),
+      'add_link' => new Link($this->t('Bulk Upload'), $url),
+    ];
+
+    return $page;
+  }
+}

--- a/modules/mrc_media/src/Form/BulkUpload.php
+++ b/modules/mrc_media/src/Form/BulkUpload.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Drupal\mrc_media\Form;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\dropzonejs\DropzoneJsUploadSave;
+use Drupal\file\Entity\File;
+use Drupal\inline_entity_form\ElementSubmit;
+use Drupal\media\Entity\Media;
+use Drupal\mrc_media\BundleSuggestion;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class BulkUpload.
+ *
+ * @package Drupal\mrc_media\Form
+ */
+class BulkUpload extends FormBase {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  private $entityTypeManager;
+
+  /**
+   * @var \Drupal\mrc_media\BundleSuggestion
+   */
+  private $bundleSuggestion;
+
+  /**
+   * @var \Drupal\dropzonejs\DropzoneJsUploadSave
+   */
+  private $dropzoneSave;
+
+  /**
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  private $currentUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('mrc_media.bundle_suggestion'),
+      $container->get('dropzonejs.upload_save'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeManager $entity_manager, BundleSuggestion $bundle_suggestion, DropzoneJsUploadSave $dropzone_save, AccountProxy $current_user) {
+    $this->entityTypeManager = $entity_manager;
+    $this->bundleSuggestion = $bundle_suggestion;
+    $this->dropzoneSave = $dropzone_save;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'mrc_media_bulk_upload';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    if (empty($form_state->get(['dropzonejs', 'media']))) {
+      $form['upload'] = [
+        '#title' => $this->t('File upload'),
+        '#type' => 'dropzonejs',
+        '#required' => TRUE,
+        '#dropzone_description' => $this->t('Drop files here to upload them'),
+        '#max_filesize' => $this->bundleSuggestion->getMaxFilesize(),
+        '#extensions' => $this->bundleSuggestion->getAllExtensions(),
+        '#max_files' => 0,
+        '#clientside_resize' => FALSE,
+      ];
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#weight' => 99,
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Upload'),
+        '#eb_widget_main_submit' => TRUE,
+        '#attributes' => ['class' => ['is-entity-browser-submit']],
+        '#button_type' => 'primary',
+      ],
+    ];
+
+
+    $form['#attached']['library'][] = 'dropzonejs/widget';
+    // Disable the submit button until the upload sucesfully completed.
+    $form['#attached']['library'][] = 'dropzonejs_eb_widget/common';
+    $original_form['#attributes']['class'][] = 'dropzonejs-disable-submit';
+
+
+    $this->getEntityForm($form, $form_state);
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $media_entities = $this->createMediaEntities($form, $form_state);
+
+    foreach ($media_entities as &$media_entity) {
+      if ($media_entity instanceof Media) {
+        $source_field = $media_entity->getSource()
+          ->getConfiguration()['source_field'];
+        // If we don't save file at this point Media entity creates another file
+        // entity with same uri for the thumbnail. That should probably be fixed
+        // in Media entity, but this workaround should work for now.
+        $media_entity->$source_field->entity->save();
+        $media_entity->save();
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if (isset($form['upload'])) {
+      $form_state->setRebuild();
+      return;
+    }
+    $count = 0;
+
+    $children = Element::children($form['entities']);
+    foreach ($children as $child) {
+      $entity_form = $form['entities'][$child];
+
+      if (!isset($entity_form['#ief_element_submit'])) {
+        continue;
+      }
+
+      foreach ($entity_form['#ief_element_submit'] as $submit_function) {
+        call_user_func_array($submit_function, [&$entity_form, $form_state]);
+      }
+
+      $count++;
+    }
+
+    drupal_set_message($this->t('Saved %count Media Items', ['%count' => $count]));
+  }
+
+  /**
+   * Gets uploaded files.
+   *
+   * We implement this to allow child classes to operate on different entity
+   * type while still having access to the files in the validate callback here.
+   *
+   * @param array $form
+   *   Form structure.
+   * @param FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return \Drupal\file\FileInterface[]
+   *   Array of uploaded files.
+   */
+  protected function getFiles(array $form, FormStateInterface $form_state) {
+
+    $files = $form_state->getValue(['dropzonejs', 'files']);
+
+    if (!$files) {
+      $files = [];
+    }
+
+    // We do some casting because $form_state->getValue() might return NULL.
+    foreach ((array) $form_state->getValue([
+      'upload',
+      'uploaded_files',
+    ], []) as $file) {
+      if (!empty($file['path']) && file_exists($file['path'])) {
+
+        $media_type = $this->bundleSuggestion->getBundleFromFile($file['path']);
+
+        if ($media_type) {
+          $additional_validators = [
+            'file_validate_size' => [
+              $this->bundleSuggestion->getMaxFileSizeBundle($media_type),
+              0,
+            ],
+          ];
+
+          $entity = $this->dropzoneSave->createFile(
+            $file['path'],
+            $this->bundleSuggestion->getMediaPath($media_type),
+            $this->bundleSuggestion->getAllExtensions(),
+            $this->currentUser,
+            $additional_validators
+          );
+
+          $files[] = $entity;
+        }
+      }
+    }
+
+    $form_state->set(['dropzonejs', 'files'], $files);
+
+    return $files;
+  }
+
+  /**
+   * Add the inline entity form after the files have been uploaded.
+   *
+   * @param array $form
+   *   Original form from getFrom().
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   */
+  private function getEntityForm(array &$form, FormStateInterface $form_state) {
+    if (isset($form['actions'])) {
+      $form['actions']['#weight'] = 100;
+    }
+
+    $form['entities'] = [
+      '#prefix' => '<div id="entities">',
+      '#suffix' => '</div>',
+      '#weight' => 99,
+    ];
+
+    $media_entities = $this->createMediaEntities($form, $form_state);
+
+    if (empty($media_entities)) {
+      $form['entities']['#markup'] = NULL;
+      return;
+    }
+
+    foreach ($media_entities as $entity) {
+
+      $form['entities'][] = [
+        '#type' => 'inline_entity_form',
+        '#entity_type' => $entity->getEntityTypeId(),
+        '#bundle' => $entity->bundle(),
+        '#default_value' => $entity,
+        '#form_mode' => 'media_browser',
+      ];
+    }
+
+    // Without this, IEF won't know where to hook into the widget. Don't pass
+    // $original_form as the second argument to addCallback(), because it's not
+    // just the entity browser part of the form, not the actual complete form.
+    ElementSubmit::addCallback($form['actions']['submit'], $form_state->getCompleteForm());
+
+    $form['#attached']['library'][] = 'mrc_media/mrc_media.browser';
+  }
+
+
+  /**
+   * @param array $form
+   *   Form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form State object.
+   *
+   * @return array
+   *   Array of media entities before saving.
+   */
+  private function createMediaEntities(array $form, FormStateInterface $form_state) {
+
+    $file_entities = [];
+    $media_entities = [];
+
+    if ($form_state->get(['dropzonejs', 'media'])) {
+      return $form_state->get(['dropzonejs', 'media']);
+    }
+
+    $files = $this->getFiles($form, $form_state);
+    foreach ($files as $file) {
+      if ($file instanceof File) {
+        $file_entities[] = $file;
+        $media_type = $this->bundleSuggestion->getBundleFromFile($file->getFileUri());
+
+        $media_entities[] = $this->entityTypeManager->getStorage('media')
+          ->create([
+            'bundle' => $media_type->id(),
+            $media_type->getSource()
+              ->getConfiguration()['source_field'] => $file,
+            'uid' => $this->currentUser->id(),
+            'status' => TRUE,
+            'type' => $media_type->getSource()->getPluginId(),
+          ]);
+      }
+    }
+    $form_state->set(['dropzonejs', 'media'], $media_entities);
+    return $media_entities;
+  }
+
+}

--- a/modules/mrc_media/src/Form/BulkUpload.php
+++ b/modules/mrc_media/src/Form/BulkUpload.php
@@ -74,7 +74,7 @@ class BulkUpload extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-
+    $save_step = TRUE;
     if (empty($form_state->get(['dropzonejs', 'media']))) {
       $form['upload'] = [
         '#title' => $this->t('File upload'),
@@ -86,6 +86,7 @@ class BulkUpload extends FormBase {
         '#max_files' => 0,
         '#clientside_resize' => FALSE,
       ];
+      $save_step = FALSE;
     }
 
     $form['actions'] = [
@@ -93,13 +94,12 @@ class BulkUpload extends FormBase {
       '#weight' => 99,
       'submit' => [
         '#type' => 'submit',
-        '#value' => $this->t('Upload'),
-        '#eb_widget_main_submit' => TRUE,
+        '#value' => $save_step ? $this->t('Save') : $this->t('Upload'),
+        '#eb_widget_main_submit' => !$save_step,
         '#attributes' => ['class' => ['is-entity-browser-submit']],
         '#button_type' => 'primary',
       ],
     ];
-
 
     $form['#attached']['library'][] = 'dropzonejs/widget';
     // Disable the submit button until the upload sucesfully completed.
@@ -136,10 +136,13 @@ class BulkUpload extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    if (isset($form['upload'])) {
+    $trigger = $form_state->getTriggeringElement();
+
+    if ($trigger['#eb_widget_main_submit']) {
       $form_state->setRebuild();
       return;
     }
+
     $count = 0;
 
     $children = Element::children($form['entities']);

--- a/modules/mrc_media/src/Form/BulkUpload.php
+++ b/modules/mrc_media/src/Form/BulkUpload.php
@@ -237,7 +237,7 @@ class BulkUpload extends FormBase {
           // Create the file entity.
           $files[] = $this->dropzoneSave->createFile(
             $file['path'],
-            $this->bundleSuggestion->getMediaPath($media_type),
+            $this->bundleSuggestion->getUploadPath($media_type),
             $this->bundleSuggestion->getAllExtensions(),
             $this->currentUser,
             $additional_validators

--- a/modules/mrc_media/src/Form/DeleteMultiple.php
+++ b/modules/mrc_media/src/Form/DeleteMultiple.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Drupal\mrc_media\Form;
+
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\user\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Provides a node deletion confirmation form.
+ */
+class DeleteMultiple extends ConfirmFormBase {
+
+  /**
+   * The array of nodes to delete.
+   *
+   * @var string[][]
+   */
+  protected $nodeInfo = [];
+
+  /**
+   * The tempstore factory.
+   *
+   * @var \Drupal\user\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $manager;
+
+  /**
+   * Constructs a DeleteMultiple form object.
+   *
+   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Entity\EntityManagerInterface $manager
+   *   The entity manager.
+   */
+  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityManagerInterface $manager) {
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->storage = $manager->getStorage('media');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('user.private_tempstore'),
+      $container->get('entity.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'media_multiple_delete_confirm';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->formatPlural(count($this->nodeInfo), 'Are you sure you want to delete this item?', 'Are you sure you want to delete these items?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('system.admin_content');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $this->nodeInfo = $this->tempStoreFactory->get('media_multiple_delete_confirm')->get(\Drupal::currentUser()->id());
+    if (empty($this->nodeInfo)) {
+      return new RedirectResponse($this->getCancelUrl()->setAbsolute()->toString());
+    }
+    /** @var \Drupal\node\NodeInterface[] $nodes */
+    $nodes = $this->storage->loadMultiple(array_keys($this->nodeInfo));
+
+    $items = [];
+    foreach ($this->nodeInfo as $id => $langcodes) {
+      foreach ($langcodes as $langcode) {
+        $node = $nodes[$id]->getTranslation($langcode);
+        $key = $id . ':' . $langcode;
+        $default_key = $id . ':' . $node->getUntranslated()->language()->getId();
+
+        // If we have a translated entity we build a nested list of translations
+        // that will be deleted.
+        $languages = $node->getTranslationLanguages();
+        if (count($languages) > 1 && $node->isDefaultTranslation()) {
+          $names = [];
+          foreach ($languages as $translation_langcode => $language) {
+            $names[] = $language->getName();
+            unset($items[$id . ':' . $translation_langcode]);
+          }
+          $items[$default_key] = [
+            'label' => [
+              '#markup' => $this->t('@label (Original translation) - <em>The following content translations will be deleted:</em>', ['@label' => $node->label()]),
+            ],
+            'deleted_translations' => [
+              '#theme' => 'item_list',
+              '#items' => $names,
+            ],
+          ];
+        }
+        elseif (!isset($items[$default_key])) {
+          $items[$key] = $node->label();
+        }
+      }
+    }
+
+    $form['medias'] = [
+      '#theme' => 'item_list',
+      '#items' => $items,
+    ];
+    $form = parent::buildForm($form, $form_state);
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if ($form_state->getValue('confirm') && !empty($this->nodeInfo)) {
+      $total_count = 0;
+      $delete_nodes = [];
+      /** @var \Drupal\Core\Entity\ContentEntityInterface[][] $delete_translations */
+      $delete_translations = [];
+      /** @var \Drupal\node\NodeInterface[] $nodes */
+      $nodes = $this->storage->loadMultiple(array_keys($this->nodeInfo));
+
+      foreach ($this->nodeInfo as $id => $langcodes) {
+        foreach ($langcodes as $langcode) {
+          $node = $nodes[$id]->getTranslation($langcode);
+          if ($node->isDefaultTranslation()) {
+            $delete_nodes[$id] = $node;
+            unset($delete_translations[$id]);
+            $total_count += count($node->getTranslationLanguages());
+          }
+          elseif (!isset($delete_nodes[$id])) {
+            $delete_translations[$id][] = $node;
+          }
+        }
+      }
+
+      if ($delete_nodes) {
+        $this->storage->delete($delete_nodes);
+        $this->logger('content')->notice('Deleted @count items.', ['@count' => count($delete_nodes)]);
+      }
+
+      if ($delete_translations) {
+        $count = 0;
+        foreach ($delete_translations as $id => $translations) {
+          $node = $nodes[$id]->getUntranslated();
+          foreach ($translations as $translation) {
+            $node->removeTranslation($translation->language()->getId());
+          }
+          $node->save();
+          $count += count($translations);
+        }
+        if ($count) {
+          $total_count += $count;
+          $this->logger('content')->notice('Deleted @count content translations.', ['@count' => $count]);
+        }
+      }
+
+      if ($total_count) {
+        drupal_set_message($this->formatPlural($total_count, 'Deleted 1 item.', 'Deleted @count posts.'));
+      }
+
+      $this->tempStoreFactory->get('media_multiple_delete_confirm')->delete(\Drupal::currentUser()->id());
+    }
+
+    $form_state->setRedirect('system.admin_content');
+  }
+
+}

--- a/modules/mrc_media/src/Form/EntityEmbedDialog.php
+++ b/modules/mrc_media/src/Form/EntityEmbedDialog.php
@@ -376,6 +376,7 @@ class EntityEmbedDialog implements ContainerInjectionInterface {
     $source_field = $render['#media']->getSource()
       ->getConfiguration()['source_field'];
     $render[$source_field][0]['#description'] = $render['#display_settings']['description'];
+    $render['#cache']['max-age'] = 0;
   }
 
 }

--- a/modules/mrc_media/src/Plugin/Action/DeleteMedia.php
+++ b/modules/mrc_media/src/Plugin/Action/DeleteMedia.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\mrc_media\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Redirects to a node deletion form.
+ *
+ * @Action(
+ *   id = "media_delete_action",
+ *   label = @Translation("Delete media"),
+ *   type = "media",
+ *   confirm_form_route_name = "media.multiple_delete_confirm"
+ * )
+ */
+class DeleteMedia extends ActionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The tempstore object.
+   *
+   * @var \Drupal\user\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new DeleteNode object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param AccountInterface $current_user
+   *   Current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+    $this->tempStore = $temp_store_factory->get('media_multiple_delete_confirm');
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('user.private_tempstore'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities) {
+    $info = [];
+    /** @var \Drupal\media\Entity\Media $node */
+    foreach ($entities as $media) {
+      $langcode = $media->language()->getId();
+      $info[$media->id()][$langcode] = $langcode;
+    }
+    $this->tempStore->set($this->currentUser->id(), $info);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($object = NULL) {
+    $this->executeMultiple([$object]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\node\NodeInterface $object */
+    return $object->access('delete', $account, $return_as_object);
+  }
+
+}

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
@@ -102,6 +102,7 @@ class EmbedCode extends WidgetBase {
       ],
     ];
     $form['#attached']['library'][] = 'mrc_media/mrc_media.browser';
+    $form['#attached']['library'][] = 'mrc_media/mrc_media.embed';
     return $form;
   }
 

--- a/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
+++ b/modules/mrc_media/src/Plugin/EntityBrowser/Widget/EmbedCode.php
@@ -35,7 +35,7 @@ class EmbedCode extends WidgetBase {
   }
 
   /**
-   * @param array $original_form
+   * @param array $form
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    * @param array $additional_widget_parameters
    *

--- a/modules/mrc_media/src/Plugin/views/field/EntityUsageLink.php
+++ b/modules/mrc_media/src/Plugin/views/field/EntityUsageLink.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\mrc_media\Plugin\views\field;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * Field handler to link entity usage entities.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("entity_usage_link")
+ */
+class EntityUsageLink extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $this->ensureMyTable();
+    // Add the field.
+    $params = $this->options['group_type'] != 'group' ? ['function' => $this->options['group_type']] : [];
+
+    $this->field_alias = $this->query->addField($this->tableAlias, 're_type', NULL, $params);
+    $this->field_alias_id = $this->query->addField($this->tableAlias, 're_id', NULL, $params);
+    $this->addAdditionalFields();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $type = $values->{$this->field_alias};
+    $id = $values->{$this->field_alias_id};
+    if(!$type || !$id){
+      return '';
+    }
+
+    $child = \Drupal::entityTypeManager()->getStorage($type)->load($id);
+    $parent = $this->getParent($child);
+    return $parent->toLink()->toRenderable();
+  }
+
+  /**
+   * @param \Drupal\Core\Entity\EntityInterface $child
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   */
+  private function getParent(EntityInterface $child) {
+    if (method_exists($child, 'getParentEntity')) {
+      $sub_parent = $child->getParentEntity();
+      return $this->getParent($sub_parent);
+    }
+    return $child;
+  }
+
+}

--- a/modules/mrc_media/src/Plugin/views/field/MediaBulkForm.php
+++ b/modules/mrc_media/src/Plugin/views/field/MediaBulkForm.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\mrc_media\Plugin\views\field;
+
+use Drupal\system\Plugin\views\field\BulkForm;
+
+/**
+ * Field handler to link entity usage entities.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("media_bulk_form")
+ */
+class MediaBulkForm extends BulkForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function emptySelectedMessage() {
+    return $this->t('No content selected.');
+  }
+
+}

--- a/modules/mrc_media/src/Routing/RouteSubscriber.php
+++ b/modules/mrc_media/src/Routing/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\mrc_media\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\mrc_media\Controller\MediaAdd;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('entity.media.add_page')) {
+      $route->setDefault('_controller', MediaAdd::class . '::addPage');
+    }
+  }
+
+}

--- a/modules/mrc_media/src/Routing/RouteSubscriber.php
+++ b/modules/mrc_media/src/Routing/RouteSubscriber.php
@@ -16,6 +16,7 @@ class RouteSubscriber extends RouteSubscriberBase {
    */
   protected function alterRoutes(RouteCollection $collection) {
     if ($route = $collection->get('entity.media.add_page')) {
+      $route->setPath('/admin/content/media/add');
       $route->setDefault('_controller', MediaAdd::class . '::addPage');
     }
   }

--- a/stanford_mrc.install
+++ b/stanford_mrc.install
@@ -127,7 +127,7 @@ function stanford_mrc_update_8001() {
 }
 
 /**
- * Enables media and resets the text format..
+ * Enables media and resets the text format.
  */
 function stanford_mrc_update_8002() {
   \Drupal::service('module_installer')->install(['mrc_media']);
@@ -135,7 +135,7 @@ function stanford_mrc_update_8002() {
 }
 
 /**
- * Resets the text format..
+ * Resets the text format.
  */
 function stanford_mrc_update_8003() {
   stanford_mrc_update_configs(TRUE, 'all');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added page to bulk upload multiple files in one drag and drop
- Added media delete action & bulk operations on that action
- Replace core /admin/content/media page with our own
- Added entity_usage module
- Added entity usage report to the admin/content/media page with links to the referencing entities.
- Fixed embed video tab in media browser.

# Needed By (Date)
- Nov 7th

# Urgency
- High

# Steps to Test

1. Checkout latest `develop` branch of [mrc_blt](https://github.com/su-hsdo/mrc_blt)
2. run `composer update --prefer-source`
3. Checkout this branch of `stanford_mrc`
4. run `drush updb -y; drush cr`
5. Navigate to /admin/content/media page
6. Click the "add Media" link at the top
7. Click the "Bulk Upload" link. this should bring you to the drag and drop similar to the wysiwyg.
8. Drag some files in.
9. Ensure they upload and your are presented with another form for each file to edit the title, alt text etc.
10. Go to create/edit a node.
11. embed the media you just uploaded and ensure it looks as expected.
12. Embed a video while you're there to see if it is fixed.
13. After saving the content with the media items, go back to the /admin/content/media page
14. Ensure the usage has incremented for the media you embeded.
15. click on the "Used In" for that item.
16. validate you see a summary of where the media item is embed and you can click to that entity.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)