### PR TITLE
MRCD8-191 Added view paragraph type

### DIFF
--- a/modules/mrc_paragraphs_view/config/install/core.entity_form_display.paragraph.mrc_view.default.yml
+++ b/modules/mrc_paragraphs_view/config/install/core.entity_form_display.paragraph.mrc_view.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.mrc_view.field_mrc_view
+    - paragraphs.paragraphs_type.mrc_view
+  module:
+    - viewfield
+id: paragraph.mrc_view.default
+targetEntityType: paragraph
+bundle: mrc_view
+mode: default
+content:
+  field_mrc_view:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: viewfield_select
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/mrc_paragraphs_view/config/install/core.entity_view_display.paragraph.mrc_view.default.yml
+++ b/modules/mrc_paragraphs_view/config/install/core.entity_view_display.paragraph.mrc_view.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.mrc_view.field_mrc_view
+    - paragraphs.paragraphs_type.mrc_view
+  module:
+    - viewfield
+id: paragraph.mrc_view.default
+targetEntityType: paragraph
+bundle: mrc_view
+mode: default
+content:
+  field_mrc_view:
+    weight: 0
+    label: hidden
+    settings:
+      view_title: hidden
+      empty_view_title: hidden
+      always_build_output: 0
+    third_party_settings: {  }
+    type: viewfield_default
+    region: content
+hidden: {  }

--- a/modules/mrc_paragraphs_view/config/install/field.field.paragraph.mrc_view.field_mrc_view.yml
+++ b/modules/mrc_paragraphs_view/config/install/field.field.paragraph.mrc_view.field_mrc_view.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_mrc_view
+    - paragraphs.paragraphs_type.mrc_view
+  module:
+    - viewfield
+id: paragraph.mrc_view.field_mrc_view
+field_name: field_mrc_view
+entity_type: paragraph
+bundle: mrc_view
+label: View
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  force_default: 0
+  allowed_views: { }
+  allowed_display_types:
+    block: block
+    page: page
+  handler: 'default:view'
+  handler_settings: {  }
+field_type: viewfield

--- a/modules/mrc_paragraphs_view/config/install/field.storage.paragraph.field_mrc_view.yml
+++ b/modules/mrc_paragraphs_view/config/install/field.storage.paragraph.field_mrc_view.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - viewfield
+    - views
+id: paragraph.field_mrc_view
+field_name: field_mrc_view
+entity_type: paragraph
+type: viewfield
+settings:
+  target_type: view
+module: viewfield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc_paragraphs_view/config/install/paragraphs.paragraphs_type.mrc_view.yml
+++ b/modules/mrc_paragraphs_view/config/install/paragraphs.paragraphs_type.mrc_view.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: mrc_view
+label: View
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/modules/mrc_paragraphs_view/mrc_paragraphs_view.info.yml
+++ b/modules/mrc_paragraphs_view/mrc_paragraphs_view.info.yml
@@ -1,0 +1,10 @@
+name: MRC Paragraph View
+description: A paragraph type to embed views.
+core: 8.x
+type: module
+version: VERSION
+package: Stanford MRC
+dependencies:
+  - viewfield
+  - paragraphs
+  - views


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- New paragraph type for view embeding

# Needed By (Date)
- End of sprint

# Urgency
- medium

# Steps to Test

1. Checkout this branch & same branch of [mrc_blt](https://github.com/SU-HSDO/mrc_blt/pull/10)
2. `composer update --prefer-source`
3. `drush en mrc_paragraphs_view -y`
4. create basic page with `View` paragraph type.
5. If the display select list is broken, adjust chosen settings at `/admin/config/user-interface/chosen` to `select:not([name*='display_id'])` and retry paragraph type.
6. ensure the view displays on the node.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)