### PR TITLE
views_block_filter_block ported module

### DIFF
--- a/modules/mrc_page/config/install/core.entity_form_display.node.stanford_basic_page.default.yml
+++ b/modules/mrc_page/config/install/core.entity_form_display.node.stanford_basic_page.default.yml
@@ -3,10 +3,14 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_basic_page.field_s_mrc_page_bricks
+    - field.field.node.stanford_basic_page.field_s_mrc_page_sidebar_block
     - node.type.stanford_basic_page
   module:
+    - block_field
     - bricks_inline
     - path
+_core:
+  default_config_hash: d9aq-sWwUJPgZfe86Q_5qx-NV-1GjVUzTUPtXE_uZEw
 id: node.stanford_basic_page.default
 targetEntityType: node
 bundle: stanford_basic_page
@@ -14,12 +18,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_s_mrc_page_bricks:
-    weight: 121
+    weight: 7
     settings:
       form_mode: default
       override_labels: '1'
@@ -31,9 +35,17 @@ content:
     third_party_settings: {  }
     type: bricks_tree_inline
     region: content
+  field_s_mrc_page_sidebar_block:
+    weight: 8
+    settings:
+      plugin_id: ''
+      settings: {  }
+    third_party_settings: {  }
+    type: block_field_default
+    region: content
   path:
     type: path
-    weight: 30
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -41,26 +53,26 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 3
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 6
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 4
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -68,11 +80,14 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
 hidden: {  }

--- a/modules/mrc_page/config/install/core.entity_view_display.node.stanford_basic_page.default.yml
+++ b/modules/mrc_page/config/install/core.entity_view_display.node.stanford_basic_page.default.yml
@@ -3,8 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_basic_page.field_s_mrc_page_bricks
+    - field.field.node.stanford_basic_page.field_s_mrc_page_sidebar_block
     - node.type.stanford_basic_page
   module:
+    - block_field
     - bricks
     - ds
     - mrc_ds_blocks
@@ -26,17 +28,19 @@ third_party_settings:
         follow_parent: '0'
         suggestion: main
       parent_name: ''
-      weight: 20
+      weight: 0
+      region: sidebar
   ds:
     regions:
-      content:
-        - field_s_mrc_page_bricks
       sidebar:
         - 'menu_block:main'
+        - field_s_mrc_page_sidebar_block
+      content:
+        - field_s_mrc_page_bricks
     layout:
-      disable_css: false
-      library: null
       id: pattern_node_basic
+      library: null
+      disable_css: false
       entity_classes: all_classes
       settings:
         pattern:
@@ -49,7 +53,7 @@ bundle: stanford_basic_page
 mode: default
 content:
   field_s_mrc_page_bricks:
-    weight: 101
+    weight: 2
     label: hidden
     settings:
       view_mode: default
@@ -57,8 +61,12 @@ content:
     third_party_settings: {  }
     type: bricks_nested
     region: content
-  links:
-    weight: 100
-    region: content
+  field_s_mrc_page_sidebar_block:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: block_field
+    region: sidebar
 hidden:
   links: true

--- a/modules/mrc_page/config/install/field.field.node.stanford_basic_page.field_s_mrc_page_sidebar_block.yml
+++ b/modules/mrc_page/config/install/field.field.node.stanford_basic_page.field_s_mrc_page_sidebar_block.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_s_mrc_page_sidebar_block
+    - node.type.stanford_basic_page
+  module:
+    - block_field
+id: node.stanford_basic_page.field_s_mrc_page_sidebar_block
+field_name: field_s_mrc_page_sidebar_block
+entity_type: node
+bundle: stanford_basic_page
+label: 'Sidebar Block'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  plugin_ids: {  }
+field_type: block_field

--- a/modules/mrc_page/config/install/field.storage.node.field_s_mrc_page_sidebar_block.yml
+++ b/modules/mrc_page/config/install/field.storage.node.field_s_mrc_page_sidebar_block.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_field
+    - node
+id: node.field_s_mrc_page_sidebar_block
+field_name: field_s_mrc_page_sidebar_block
+entity_type: node
+type: block_field
+settings: {  }
+module: block_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/mrc_page/mrc_page.post_update.php
+++ b/modules/mrc_page/mrc_page.post_update.php
@@ -5,17 +5,55 @@
  * mrc_page.post_update.php
  */
 
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
+
+/**
+ * @param string $entity_type
+ * @param string $bundle
+ * @param string $field_name
+ * @param string $type
+ * @param string $label
+ * @param int $cardinality
+ */
+function mrc_page_create_field($entity_type, $bundle, $field_name, $type, $label, $cardinality = -1) {
+  $field_storage_config = FieldStorageConfig::loadByName($entity_type, $field_name);
+  if (empty($field_storage_config)) {
+    FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => $type,
+      'cardinality' => $cardinality,
+    ])->save();
+  }
+
+  $field_instance = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+  if (empty($field_instance)) {
+    FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => $label,
+    ])->save();
+  }
+}
+
+
 /**
  * Adds menu block to node display.
  */
 function mrc_page_post_update_8_0_4() {
-  \Drupal::service('module_installer')->install(['menu_block']);
+  \Drupal::service('module_installer')->install(['menu_block', 'block_field']);
+  mrc_page_create_field('node', 'stanford_basic_page', 'field_s_mrc_page_sidebar_block', 'block_field', 'Sidebar Block', -1);
 
   module_load_install('stanford_mrc');
   $path = drupal_get_path('module', 'mrc_page') . '/config/install';
 
   $configs = [
     'core.entity_view_display.node.stanford_basic_page.default',
+    'core.entity_form_display.node.stanford_basic_page.default',
+    'field.field.node.stanford_basic_page.field_s_mrc_page_sidebar_block',
+    'field.storage.node.field_s_mrc_page_sidebar_block',
   ];
   stanford_mrc_update_configs(TRUE, $configs, $path);
 }

--- a/modules/views_block_filter_block/README.md
+++ b/modules/views_block_filter_block/README.md
@@ -1,0 +1,16 @@
+Views Block Exposed Filter Block
+=================================
+
+This is a a utility Drupal extension that allows you to configure exposed
+filters on block display views to be displayed and placed as standard blocks.
+Although this is possible by default for page display views, this functionality
+is not possible for block display views without this module.
+
+This extension requires no configuration. Just install it and it works; you
+should see an "exposed filter in block" option under the "advanced" pane of the
+Views UI for all block display views.
+
+### Dependencies
+* [Views][] (obviously)
+
+[Views]: https://drupal.org/project/views

--- a/modules/views_block_filter_block/src/Plugin/views/vbfbPluginDisplayBlock.php
+++ b/modules/views_block_filter_block/src/Plugin/views/vbfbPluginDisplayBlock.php
@@ -24,6 +24,7 @@ use Drupal\views\Plugin\views\display\Block;
  * @see \Drupal\views\Plugin\Derivative\ViewsBlock
  */
 class vbfbPluginDisplayBlock extends Block {
+
   /**
    * Allows block views to put exposed filter forms in blocks.
    */
@@ -37,4 +38,5 @@ class vbfbPluginDisplayBlock extends Block {
   public function usesExposed() {
     return TRUE;
   }
+
 }

--- a/modules/views_block_filter_block/src/Plugin/views/vbfbPluginDisplayBlock.php
+++ b/modules/views_block_filter_block/src/Plugin/views/vbfbPluginDisplayBlock.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\views_block_filter_block\Plugin\views;
+
+use Drupal\views\Plugin\views\display\Block;
+
+/**
+ * The plugin that handles a block.
+ *
+ * @ingroup views_display_plugins
+ *
+ * @ViewsDisplay(
+ *   id = "vbfb_plugin_display_block",
+ *   title = @Translation("Block"),
+ *   help = @Translation("Display the view as a block."),
+ *   theme = "views_view",
+ *   register_theme = FALSE,
+ *   uses_hook_block = TRUE,
+ *   contextual_links_locations = {"block"},
+ *   admin = @Translation("Block")
+ * )
+ *
+ * @see \Drupal\views\Plugin\block\block\ViewsBlock
+ * @see \Drupal\views\Plugin\Derivative\ViewsBlock
+ */
+class vbfbPluginDisplayBlock extends Block {
+  /**
+   * Allows block views to put exposed filter forms in blocks.
+   */
+  public function usesExposedFormInBlock() {
+    return TRUE;
+  }
+
+  /**
+   * Block views use exposed widgets only if AJAX is set.
+   */
+  public function usesExposed() {
+    return TRUE;
+  }
+}

--- a/modules/views_block_filter_block/tests/views_block_filter_block.test
+++ b/modules/views_block_filter_block/tests/views_block_filter_block.test
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * @file
+ * Tests for the Views Block Exposed Filter Block module.
+ */
+
+
+/**
+ * Base/helper class for Views Block Filter Block tests.
+ */
+class ViewsBlockFilterBlockBase extends DrupalWebTestCase {
+  function setUp($modules = array()) {
+    // Enable views_ui.
+    parent::setUp($modules + array('block', 'node', 'views', 'views_block_filter_block'));
+
+    // Create and log in a user with administer views permission.
+    $this->adminUser = $this->drupalCreateUser(array('administer modules', 'administer views', 'administer blocks', 'bypass node access', 'access user profiles', 'view revisions'));
+    $this->drupalLogin($this->adminUser);
+
+    variable_set('clean_url', TRUE);
+  }
+
+  /**
+   * Click a link to perform an operation on a view.
+   *
+   * In general, we expect lots of links titled "enable" or "disable" on the
+   * various views listing pages, and they might have tokens in them. So we
+   * need special code to find the correct one to click.
+   *
+   * @param $label
+   *   Text between the anchor tags of the desired link.
+   * @param $unique_href_part
+   *   A unique string that is expected to occur within the href of the desired
+   *   link. For example, if the link URL is expected to look like
+   *   "admin/structure/views/view/frontpage/...", then "/frontpage/" could be
+   *   passed as the expected unique string.
+   *
+   * @return
+   *   The page content that results from clicking on the link, or FALSE on
+   *   failure. Failure also results in a failed assertion.
+   */
+  protected function clickViewsOperationLink($label, $unique_href_part) {
+    $links = $this->xpath('//a[normalize-space(text())=:label]', array(':label' => $label));
+    foreach ($links as $link_index => $link) {
+      $position = strpos($link['href'], $unique_href_part);
+      if ($position !== FALSE) {
+        $index = $link_index;
+        break;
+      }
+    }
+    $this->assertTrue(isset($index), t('Link to "@label" containing @part found.', array('@label' => $label, '@part' => $unique_href_part)));
+    if (isset($index)) {
+      return $this->clickLink($label, $index);
+    }
+    else {
+      return FALSE;
+    }
+  }
+}
+
+/**
+ * Tests that block views can be created with exposed filter blocks via the
+ * Views UI.
+ */
+class ViewsBlockFilterBlockBasicUICase extends ViewsBlockFilterBlockBase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Views Block Filter Block UI Tests',
+      'description' => 'Test creating a block view and ensure the exposed filter block option exists and is saved.',
+      'group' => 'VBFB',
+    );
+  }
+
+  function setUp() {
+    parent::setUp(array('views_ui'));
+  }
+
+  public function testCreateBlockViewAndSave() {
+    // Create a simple and not at all useful view.
+    $view = array();
+    $view['human_name'] = $this->randomName(16);
+    $view['name'] = strtolower($this->randomName(16));
+    $view['description'] = $this->randomName(16);
+    $view['page[create]'] = FALSE;
+    $view['block[create]'] = TRUE;
+    $this->drupalPost('admin/structure/views/add', $view, t('Continue & edit'));
+
+    // Assert that the "exposed form in block" text exists; click and submit it.
+    $this->assertText('Exposed form in block', 'Exposed form in block text exists.');
+    $this->clickViewsOperationLink('No', '/exposed_block');
+    $this->drupalPost(NULL, array('exposed_block' => TRUE), 'Apply');
+
+    // Save the view.
+    $this->drupalPost(NULL, array(), 'Save');
+
+    // Ensure the view exists on the Views overview page.
+    $this->drupalGet('admin/structure/views');
+    $this->assertText($view['human_name'], 'View saved successfully.');
+
+    // Ensure the exposed block edit value was saved.
+    $this->clickViewsOperationLink('Edit', $view['name'] . '/edit');
+    $this->clickViewsOperationLink('Yes', '/exposed_block');
+
+    // Ensure the exposed form block exists.
+    $this->drupalGet('/admin/structure/block');
+    $this->assertText('Exposed form: ' . $view['name'] . '-block', 'Exposed form block created successfully.');
+  }
+}
+
+/**
+ * Tests exposed block placement visibility and basic functionality.
+ */
+class ViewsBlockFilterBlockExposedBlockCase extends ViewsBlockFilterBlockBase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Views Block Filter Exposed Block Tests',
+      'description' => 'Test creating placing and using an exposed filter block for a block display View.',
+      'group' => 'VBFB',
+    );
+  }
+
+  function setUp() {
+    parent::setUp(array('views_block_filter_block_test'));
+
+    // Clear all caches to ensure Views/blocks have been loaded.
+    drupal_flush_all_caches();
+
+    // Move View blocks into visible regions.
+    db_update('block')
+      ->fields(array(
+        'region' => 'content',
+        'status' => 1,
+      ))
+      ->condition('module', 'views')
+      ->execute();
+  }
+
+  public function testPlacedBlock() {
+    // Visit the front page, where the filter block should appear.
+    $this->drupalGet('node');
+
+    // Ensure the configured filters are exposed.
+    $this->assertFieldByName('status', 1, 'Found the exposed filter block.');
+
+    // Ensure the form action points to the absolute URL of the current page.
+    $expected_url = $this->getAbsoluteUrl('node');
+    $form = $this->xpath($this->buildXPathQuery('//form[@id=:id]', array(':id' => 'views-exposed-form-test-view-block')));
+    $action = (string) $form[0]['action'];
+    $this->assertEqual($action, $expected_url, 'The exposed filter block action is set correctly.');
+
+    // Try using the exposed filter form.
+    $this->drupalGet($action . '?status=0');
+
+    // Ensure the value was changed.
+    $this->assertFieldByName('status', 0, 'The exposed filter form worked as expected.');
+  }
+
+  public function testModuleCleanup() {
+    // For sanity, ensure we have a block to begin with.
+    $select = db_select('block')
+      ->fields('block')
+      ->condition('delta', '-exp-test_view-block')
+      ->execute();
+    $rows = $select->fetchAllAssoc('delta');
+    $this->assertIdentical(count($rows), 1, t('Sanity check: exposed filter block exists in DB.'));
+
+    // Disable the module.
+    $edit = array('modules[Views][views_block_filter_block][enable]' => FALSE);
+    $this->drupalPost('admin/modules', $edit, t('Save configuration'));
+
+    // Ensure the exposed filter block was removed on module disable.
+    $select = db_select('block')
+      ->fields('block')
+      ->condition('delta', '-exp-test_view-block')
+      ->execute();
+    $rows = $select->fetchAllAssoc('delta');
+    $this->assertIdentical(count($rows), 0, t('Module disable removed exposed filter block.'));
+  }
+
+}

--- a/modules/views_block_filter_block/tests/views_block_filter_block_test/views_block_filter_block_test.info
+++ b/modules/views_block_filter_block/tests/views_block_filter_block_test/views_block_filter_block_test.info
@@ -1,0 +1,6 @@
+name = Views Block Exposed Filter Block Test
+description = Test module for Views Block Exposed filter Block.
+package = Views
+core = 7.x
+dependencies[] = views_block_filter_block
+hidden = TRUE

--- a/modules/views_block_filter_block/tests/views_block_filter_block_test/views_block_filter_block_test.module
+++ b/modules/views_block_filter_block/tests/views_block_filter_block_test/views_block_filter_block_test.module
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Hooks and functions for the VBFB test module. No working code contained here.
+ */
+
+
+/**
+ * Implements hook_views_api().
+ */
+function views_block_filter_block_test_views_api() {
+  return array(
+    'version' => 3,
+  );
+}
+
+/**
+ * Implements hook_views_default_views().
+ */
+function views_block_filter_block_test_views_default_views() {
+  $views = array();
+
+  $view = new view();
+  $view->name = 'test_view';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Test View';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test View';
+  $handler->display->display_options['use_ajax'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '5';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = '1';
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['status']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['status']['expose']['label'] = 'Published';
+  $handler->display->display_options['filters']['status']['expose']['operator'] = 'status_op';
+  $handler->display->display_options['filters']['status']['expose']['identifier'] = 'status';
+  $handler->display->display_options['filters']['status']['expose']['required'] = TRUE;
+  $handler->display->display_options['filters']['status']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+  );
+
+  /* Display: Block */
+  $handler = $view->new_display('block', 'Block', 'block');
+  $handler->display->display_options['exposed_block'] = TRUE;
+
+  $views[$view->name] = $view;
+
+  return $views;
+}

--- a/modules/views_block_filter_block/views_block_filter_block.info.yml
+++ b/modules/views_block_filter_block/views_block_filter_block.info.yml
@@ -1,0 +1,7 @@
+name: Views Block Exposed Filter Block
+type: module
+description: 'Provides blocks for Views exposed filters on View blocks. Port of views_block_filter_block and will be deprecated when that module is available.'
+package: Views
+core: 8.x
+dependencies:
+  - views

--- a/modules/views_block_filter_block/views_block_filter_block.install
+++ b/modules/views_block_filter_block/views_block_filter_block.install
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Install and update hooks and functions for VBFB.
+ */
+
+/**
+ * Implements hook_disable().
+ */
+//function views_block_filter_block_disable() {
+//  $views = views_get_all_views();
+//  $needs_save = array();
+//  $block_needs_delete = array();
+//
+//  // Iterate through all Views and note the Views that need updating.
+//  foreach ($views as $name => &$view) {
+//    foreach ($view->display as $display => &$settings) {
+//      $options = &$settings->display_options;
+//
+//      // This View is configured to use this module. Remove the dependency and
+//      // re-save the View to the database; also remove the block entry.
+//      if (isset($options['exposed_block']) && $options['exposed_block']) {
+//        unset($options['exposed_block']);
+//        $needs_save[$name] = $view;
+//        $block_needs_delete[] = '-exp-' . $name . '-' . $display;
+//      }
+//    }
+//  }
+//
+//  // Iterate through all Views that need updating, and save them.
+//  foreach ($needs_save as $view_needs_save) {
+//    $view_needs_save->save();
+//  }
+//
+//  // If there are displays that need deleting, delete them.
+//  if ($block_needs_delete) {
+//    db_delete('block')
+//      ->condition('module', 'views')
+//      ->condition('delta', $block_needs_delete, 'IN')
+//      ->execute();
+//  }
+//}

--- a/modules/views_block_filter_block/views_block_filter_block.module
+++ b/modules/views_block_filter_block/views_block_filter_block.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Hooks and functions for the Views Block Exposed Filter Block module.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_views_plugins_display_alter().
+ */
+function views_block_filter_block_views_plugins_display_alter(array &$plugins) {
+  // Force the block display plugin to use our block display plugin.
+  $plugins['block']['class'] = 'Drupal\views_block_filter_block\Plugin\views\vbfbPluginDisplayBlock';
+}
+
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function views_block_filter_block_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $storage = $form_state->getStorage();
+  $view = $storage['view'];
+
+  // Only react on block Views specifically configured with exposed form blocks.
+  if (get_class($view->display_handler) == 'Drupal\views_block_filter_block\Plugin\views\vbfbPluginDisplayBlock') {
+    if ($view->display_handler->getOption('exposed_block')) {
+      // Ensure that the fallback form action is the current page.
+      $request = \Drupal::request();
+      $url = Url::createFromRequest($request);
+      $url->setAbsolute();
+      $form['#action'] = $url->toString();
+    }
+  }
+}

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -4,5 +4,6 @@
  * Release 8.0.4 changes.
  */
 function stanford_mrc_post_update_8_0_4() {
-  \Drupal::service('module_installer')->install(['mrc_paragraphs_webform']);
+  $modules = ['mrc_paragraphs_webform', 'views_block_filter_block'];
+  \Drupal::service('module_installer')->install($modules);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added port of views_block_filter_block since its not a full D8 project yet.

# Needed By (Date)
- ASAP

# Urgency
- High

# Steps to Test

1. Checkout branch
2. enable views_block_filter_block
3. edit view block that has a form
4. in the advanced section set the exposed form to be a block.
5. place block on the page with the view and test it out.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)