### PR TITLE
MRCD8-229 Added contextual filter to allow user to choose which event type

### DIFF
--- a/modules/mrc_events/config/install/views.view.mrc_events.yml
+++ b/modules/mrc_events/config/install/views.view.mrc_events.yml
@@ -18,6 +18,7 @@ dependencies:
     - taxonomy
     - ui_patterns_views
     - user
+    - views_taxonomy_term_name_depth
 id: mrc_events
 label: 'MRC Events'
 module: views
@@ -3043,11 +3044,54 @@ display:
       display_extenders: {  }
       display_description: ''
       block_hide_empty: true
+      arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '0'
+          vocabularies:
+            event_type: event_type
+          break_phrase: true
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
+      defaults:
+        arguments: false
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions

--- a/modules/mrc_events/mrc_events.module
+++ b/modules/mrc_events/mrc_events.module
@@ -52,3 +52,10 @@ function mrc_events_node_validate_date(array &$element, FormStateInterface $form
     $form_state->setValue('field_s_event_date', $date);
   }
 }
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function mrc_events_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
+//  ddl($query);
+}

--- a/modules/mrc_events/mrc_events.post_update.php
+++ b/modules/mrc_events/mrc_events.post_update.php
@@ -15,3 +15,11 @@ function mrc_events_post_update_8_0_4() {
   $path = drupal_get_path('module', 'mrc_events') . '/config/install';
   stanford_mrc_update_configs(TRUE, $configs, $path);
 }
+
+/**
+ * Enable new module and revert view.
+ */
+function mrc_events_post_update_8_0_5(){
+  \Drupal::service('module_installer')->install(['views_taxonomy_term_name_depth']);
+  mrc_events_post_update_8_0_4();
+}


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- Added contextual filter in the upcoming events view.
- Might have merge conflicts with https://github.com/SU-HSDO/stanford_mrc/pull/48 but easily cleared up in the `post_update` hook.

# Needed By (Date)
- End of sprint

# Urgency
- Medium

# Steps to Test
0. Make sure to update composer (new dependency)
1. Sync to prod, Checkout the branch & update database
2. Create/edit a basic page.
3. choose a view brick and choose the "MRC Events" -> "Upcoming List" view
4. in the contextual arguments field, provide one or more of the event type terms: "Conferences", "Workshops", "Lectures". if using more than 1, separate them with a "+"
5. ensure the appropriate content displays in the view.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)