### PR TITLE
MRCD8-226 upped font weight for lead font

### DIFF
--- a/themes/math_research_center/css/base/base.css
+++ b/themes/math_research_center/css/base/base.css
@@ -1,3 +1,3 @@
-img{max-width:100%;height:auto}
+img{max-width:100%;height:auto}.decanter-font-lead{font-weight:400}
 
 /*# sourceMappingURL=base.css.map */

--- a/themes/math_research_center/scss/base/base.scss
+++ b/themes/math_research_center/scss/base/base.scss
@@ -2,3 +2,7 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+.decanter-font-lead {
+  font-weight: 400;
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Upped font weight for Lead Font (override Decanter default)

# Needed By (Date)
- End of sprint (2/15)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Add Lead Font style through the WYSIWYG
3. Verify that the new font weight is 400 (not 100)

# Affected Projects or Products
- stanford_mrc
- MRC

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/MRCD8-226

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)