### PR TITLE
MRCD8-230 Event Series Term changes

### DIFF
--- a/config/install/chosen.settings.yml
+++ b/config/install/chosen.settings.yml
@@ -1,8 +1,8 @@
 minimum_single: 0
 minimum_multiple: 0
 disable_search_threshold: 0
-minimum_width: 100
-jquery_selector: select
+minimum_width: 200
+jquery_selector: 'select:not([name*="[display_id]"])'
 search_contains: true
 disable_search: false
 allow_single_deselect: false
@@ -10,6 +10,5 @@ placeholder_text_multiple: 'Choose some options'
 placeholder_text_single: 'Choose an option'
 no_results_text: 'No results match'
 disabled_themes:
-  bartik: '0'
   seven: '0'
 chosen_include: 2

--- a/modules/mrc_events/config/install/views.view.mrc_events.yml
+++ b/modules/mrc_events/config/install/views.view.mrc_events.yml
@@ -605,7 +605,7 @@ display:
             description: ''
             use_operator: false
             operator: field_s_event_type_target_id_op
-            identifier: field_s_event_type_target_id
+            identifier: type
             required: false
             remember: false
             multiple: false
@@ -651,7 +651,7 @@ display:
             description: ''
             use_operator: false
             operator: field_mrc_event_series_target_id_op
-            identifier: field_mrc_event_series_target_id
+            identifier: series
             required: false
             remember: false
             multiple: false
@@ -1189,15 +1189,16 @@ display:
         use_more_text: false
         link_display: false
         link_url: false
+        relationships: false
       filter_groups:
         operator: AND
         groups:
           1: AND
       arguments:
-        field_mrc_event_series_target_id:
-          id: field_mrc_event_series_target_id
-          table: node__field_mrc_event_series
-          field: field_mrc_event_series_target_id
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
           relationship: none
           group_type: group
           admin_label: ''
@@ -1206,8 +1207,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: 'Past {{ arguments.tid }} Events'
           default_argument_type: taxonomy_tid
           default_argument_options:
             term_page: '1'
@@ -1225,14 +1226,21 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:taxonomy_term'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              mrc_event_series: mrc_event_series
+            operation: view
+            multiple: 0
+            access: false
           break_phrase: false
-          not: false
-          plugin_id: numeric
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
       title: 'Past Events'
       style:
         type: default
@@ -1590,8 +1598,21 @@ display:
       use_more_always: false
       use_more_text: 'See all past events'
       link_display: custom_url
-      link_url: 'events/past-events?series={{ raw_arguments.field_mrc_event_series_target_id }} '
+      link_url: 'events/past-events?series={{ arguments.field_mrc_event_series_target_id }}'
       block_hide_empty: true
+      relationships:
+        term_node_tid:
+          id: term_node_tid
+          table: node_field_data
+          field: term_node_tid
+          relationship: none
+          group_type: group
+          admin_label: term
+          required: true
+          vids:
+            - mrc_event_series
+          entity_type: node
+          plugin_id: node_term_data
     cache_metadata:
       max-age: -1
       contexts:
@@ -1686,15 +1707,16 @@ display:
         use_more_text: false
         link_display: false
         link_url: false
+        relationships: false
       filter_groups:
         operator: AND
         groups:
           1: AND
       arguments:
-        field_mrc_event_series_target_id:
-          id: field_mrc_event_series_target_id
-          table: node__field_mrc_event_series
-          field: field_mrc_event_series_target_id
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
           relationship: none
           group_type: group
           admin_label: ''
@@ -1703,8 +1725,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: 'Upcoming {{ arguments.tid }} Events'
           default_argument_type: taxonomy_tid
           default_argument_options:
             term_page: '1'
@@ -1722,14 +1744,21 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:taxonomy_term'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              mrc_event_series: mrc_event_series
+            operation: view
+            multiple: 0
+            access: false
           break_phrase: false
-          not: false
-          plugin_id: numeric
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
       title: 'Upcoming Events'
       style:
         type: default
@@ -2083,12 +2112,25 @@ display:
         options:
           items_per_page: 2
           offset: 0
-      use_more: true
+      use_more: false
       use_more_always: false
       use_more_text: 'View all upcoming events'
-      link_display: custom_url
+      link_display: '0'
       link_url: 'events?series={{ arguments.field_mrc_event_series_target_id }}'
       block_hide_empty: true
+      relationships:
+        term_node_tid:
+          id: term_node_tid
+          table: node_field_data
+          field: term_node_tid
+          relationship: none
+          group_type: group
+          admin_label: term
+          required: true
+          vids:
+            - mrc_event_series
+          entity_type: node
+          plugin_id: node_term_data
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/mrc_helper/config/install/core.entity_view_display.taxonomy_term.mrc_event_series.default.yml
+++ b/modules/mrc_helper/config/install/core.entity_view_display.taxonomy_term.mrc_event_series.default.yml
@@ -1,4 +1,3 @@
-uuid: 3b7e33d3-c67c-481d-aa62-6454cab65c09
 langcode: en
 status: true
 dependencies:

--- a/modules/mrc_helper/config/install/core.entity_view_display.taxonomy_term.mrc_event_series.default.yml
+++ b/modules/mrc_helper/config/install/core.entity_view_display.taxonomy_term.mrc_event_series.default.yml
@@ -1,3 +1,4 @@
+uuid: 3b7e33d3-c67c-481d-aa62-6454cab65c09
 langcode: en
 status: true
 dependencies:
@@ -23,7 +24,7 @@ third_party_settings:
         views_label_checkbox: 0
         views_label: ''
       parent_name: ''
-      weight: 20
+      weight: 5
       region: bottom_left
     'views_block:mrc_events-event_series_upcoming_events':
       config:
@@ -36,7 +37,7 @@ third_party_settings:
         views_label_checkbox: 0
         views_label: ''
       parent_name: ''
-      weight: 20
+      weight: 4
       region: bottom_left
     'views_block:mrc_news-event_series_related_news':
       config:
@@ -49,7 +50,7 @@ third_party_settings:
         views_label_checkbox: 0
         views_label: ''
       parent_name: ''
-      weight: 20
+      weight: 6
       region: bottom_right
     'views_block:mrc_visitor-event_series_visitors':
       config:
@@ -62,7 +63,7 @@ third_party_settings:
         views_label_checkbox: 0
         views_label: ''
       parent_name: ''
-      weight: 20
+      weight: 7
       region: footer
     'menu_block:main':
       config:
@@ -79,7 +80,8 @@ third_party_settings:
         follow_parent: '0'
         suggestion: main
       parent_name: ''
-      weight: 20
+      weight: 0
+      region: sidebar
   ds:
     layout:
       id: pattern_terms_event_series
@@ -97,8 +99,8 @@ third_party_settings:
         - field_mrc_event_series_image
         - description
       bottom_left:
-        - 'views_block:mrc_events-event_series_past_events'
         - 'views_block:mrc_events-event_series_upcoming_events'
+        - 'views_block:mrc_events-event_series_past_events'
       bottom_right:
         - 'views_block:mrc_news-event_series_related_news'
       footer:
@@ -111,12 +113,12 @@ content:
   description:
     label: hidden
     type: text_default
-    weight: 2
+    weight: 3
     region: top
     settings: {  }
     third_party_settings: {  }
   field_mrc_event_series_image:
-    weight: 1
+    weight: 2
     label: hidden
     settings:
       image_style: ''
@@ -125,7 +127,7 @@ content:
     type: image
     region: top
   field_mrc_event_series_name:
-    weight: 0
+    weight: 1
     label: hidden
     settings:
       link_to_entity: false

--- a/modules/mrc_news/config/install/core.entity_form_display.node.stanford_news_item.default.yml
+++ b/modules/mrc_news/config/install/core.entity_form_display.node.stanford_news_item.default.yml
@@ -58,13 +58,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_mrc_event_series:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 17
     region: content
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_s_news_byline:
     type: string_textfield

--- a/modules/mrc_news/config/install/views.view.mrc_news.yml
+++ b/modules/mrc_news/config/install/views.view.mrc_news.yml
@@ -9,11 +9,13 @@ dependencies:
     - image.style.large
     - image.style.mrc_news_thumbnail
     - node.type.stanford_news_item
+    - taxonomy.vocabulary.mrc_event_series
   module:
     - datetime
     - image
     - link
     - node
+    - taxonomy
     - ui_patterns_views
     - user
 id: mrc_news
@@ -90,12 +92,11 @@ display:
           default_field_elements: 1
           inline:
             path: 0
-            field_s_news_source_1: 0
             title: 0
             field_s_news_date: 0
             field_s_news_image: 0
             field_s_news_categories: 0
-            field_s_news_source: 0
+            field_s_news_link: 0
           separator: ''
           hide_empty: 0
           pattern: news_card
@@ -105,26 +106,26 @@ display:
               weight: 0
               plugin: views_row
               source: title
+            'views_row:field_s_news_link':
+              destination: link
+              weight: 1
+              plugin: views_row
+              source: field_s_news_link
             'views_row:field_s_news_date':
               destination: time
-              weight: 1
+              weight: 2
               plugin: views_row
               source: field_s_news_date
             'views_row:field_s_news_image':
               destination: image
-              weight: 2
+              weight: 3
               plugin: views_row
               source: field_s_news_image
             'views_row:field_s_news_categories':
               destination: program
-              weight: 3
-              plugin: views_row
-              source: field_s_news_categories
-            'views_row:field_s_news_source':
-              destination: link
               weight: 4
               plugin: views_row
-              source: field_s_news_source
+              source: field_s_news_categories
       fields:
         path:
           id: path
@@ -433,10 +434,10 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        field_s_news_source:
-          id: field_s_news_source
-          table: node__field_s_news_source
-          field: field_s_news_source
+        field_s_news_link:
+          id: field_s_news_link
+          table: node__field_s_news_link
+          field: field_s_news_link
           relationship: none
           group_type: group
           admin_label: ''
@@ -446,13 +447,13 @@ display:
             alter_text: false
             text: ''
             make_link: false
-            path: '{{ field_s_news_source__uri }}'
-            absolute: true
+            path: ''
+            absolute: false
             external: false
             replace_spaces: false
             path_case: none
             trim_whitespace: false
-            alt: '{{ title }}'
+            alt: ''
             rel: ''
             link_class: ''
             prefix: ''
@@ -541,6 +542,7 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
+      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -553,6 +555,7 @@ display:
         - 'config:field.storage.node.field_s_news_categories'
         - 'config:field.storage.node.field_s_news_date'
         - 'config:field.storage.node.field_s_news_image'
+        - 'config:field.storage.node.field_s_news_link'
   event_series_related_news:
     display_plugin: block
     id: event_series_related_news
@@ -574,16 +577,17 @@ display:
         use_more_text: false
         link_display: false
         link_url: false
+        relationships: false
       pager:
         type: some
         options:
           items_per_page: 2
           offset: 0
       arguments:
-        field_mrc_event_series_target_id:
-          id: field_mrc_event_series_target_id
-          table: node__field_mrc_event_series
-          field: field_mrc_event_series_target_id
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
           relationship: none
           group_type: group
           admin_label: ''
@@ -592,8 +596,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: 'Related {{ arguments.tid }} News'
           default_argument_type: taxonomy_tid
           default_argument_options:
             term_page: '1'
@@ -611,14 +615,21 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:taxonomy_term'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              mrc_event_series: mrc_event_series
+            operation: view
+            multiple: 0
+            access: false
           break_phrase: false
-          not: false
-          plugin_id: numeric
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
       block_hide_empty: true
       style:
         type: default
@@ -1041,7 +1052,20 @@ display:
       use_more_always: false
       use_more_text: 'See all related news'
       link_display: custom_url
-      link_url: 'news?series={{ raw_arguments.field_mrc_event_series_target_id }}'
+      link_url: 'news?series={{ raw_arguments.tid }}'
+      relationships:
+        term_node_tid:
+          id: term_node_tid
+          table: node_field_data
+          field: term_node_tid
+          relationship: none
+          group_type: group
+          admin_label: term
+          required: true
+          vids:
+            - mrc_event_series
+          entity_type: node
+          plugin_id: node_term_data
     cache_metadata:
       max-age: -1
       contexts:
@@ -1063,18 +1087,138 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
+      exposed_block: true
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            stanford_news_item: stanford_news_item
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: 'Search by Title'
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              site_owner: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+        field_mrc_event_series_target_id:
+          id: field_mrc_event_series_target_id
+          table: node__field_mrc_event_series
+          field: field_mrc_event_series_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_mrc_event_series_target_id_op
+            label: 'Filter by Series'
+            description: ''
+            use_operator: false
+            operator: field_mrc_event_series_target_id_op
+            identifier: series
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              site_owner: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: mrc_event_series
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_s_news_categories'
         - 'config:field.storage.node.field_s_news_date'
         - 'config:field.storage.node.field_s_news_image'
+        - 'config:field.storage.node.field_s_news_link'
   short_list:
     display_plugin: block
     id: short_list

--- a/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
+++ b/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
@@ -2,88 +2,30 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_image
-    - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_name
-    - taxonomy.vocabulary.mrc_event_series
+    - field.field.node.stanford_visitor.body
+    - field.field.node.stanford_visitor.field_mrc_event_series
+    - field.field.node.stanford_visitor.field_s_visitor_curr_inst
+    - field.field.node.stanford_visitor.field_s_visitor_donor
+    - field.field.node.stanford_visitor.field_s_visitor_external_link
+    - field.field.node.stanford_visitor.field_s_visitor_first_name
+    - field.field.node.stanford_visitor.field_s_visitor_last_name
+    - field.field.node.stanford_visitor.field_s_visitor_photo
+    - field.field.node.stanford_visitor.field_s_visitor_position_title
+    - field.field.node.stanford_visitor.field_s_visitor_research_area
+    - field.field.node.stanford_visitor.field_s_visitor_year_visited
+    - image.style.medium
+    - node.type.stanford_visitor
   module:
     - ds
     - image
-    - mrc_ds_blocks
+    - link
+    - mrc_yearonly
     - text
+    - user
 third_party_settings:
-  mrc_ds_blocks:
-    'views_block:mrc_events-event_series_past_events':
-      config:
-        provider: views
-        admin_label: ''
-        label: ''
-        label_display: visible
-        field_mrc_event_series_target_id: ''
-        items_per_page: none
-        views_label_checkbox: 0
-        views_label: ''
-      parent_name: ''
-      weight: 5
-      region: bottom_left
-    'views_block:mrc_events-event_series_upcoming_events':
-      config:
-        provider: views
-        admin_label: ''
-        label: ''
-        label_display: visible
-        field_mrc_event_series_target_id: ''
-        items_per_page: none
-        views_label_checkbox: 0
-        views_label: ''
-      parent_name: ''
-      weight: 4
-      region: sidebar
-    'views_block:mrc_news-event_series_related_news':
-      config:
-        provider: views
-        admin_label: ''
-        label: ''
-        label_display: visible
-        field_mrc_event_series_target_id: ''
-        items_per_page: none
-        views_label_checkbox: 0
-        views_label: ''
-      parent_name: ''
-      weight: 6
-      region: bottom_right
-    'views_block:mrc_visitor-event_series_visitors':
-      config:
-        provider: views
-        admin_label: ''
-        label: ''
-        label_display: visible
-        field_mrc_event_series_target_id: ''
-        items_per_page: none
-        views_label_checkbox: 0
-        views_label: ''
-      parent_name: ''
-      weight: 7
-      region: footer
-    'menu_block:main':
-      config:
-        provider: menu_block
-        admin_label: ''
-        label: 'Main navigation'
-        label_display: visible
-        level: '1'
-        depth: '0'
-        expand: 1
-        parent: 'main:'
-        label_type: root
-        follow: 1
-        follow_parent: '0'
-        suggestion: main
-      parent_name: ''
-      weight: 0
-      region: sidebar
   ds:
     layout:
-      id: pattern_terms_event_series
+      id: pattern_node_simple
       library: null
       disable_css: false
       entity_classes: all_classes
@@ -91,46 +33,109 @@ third_party_settings:
         pattern:
           field_templates: default
     regions:
-      sidebar:
-        - 'menu_block:main'
-        - 'views_block:mrc_events-event_series_upcoming_events'
-      top:
-        - field_mrc_event_series_name
-        - field_mrc_event_series_image
-        - description
-      bottom_left:
-        - 'views_block:mrc_events-event_series_past_events'
-      bottom_right:
-        - 'views_block:mrc_news-event_series_related_news'
-      footer:
-        - 'views_block:mrc_visitor-event_series_visitors'
-id: taxonomy_term.mrc_event_series.default
-targetEntityType: taxonomy_term
-bundle: mrc_event_series
+      image:
+        - field_s_visitor_photo
+      above_break:
+        - node_title
+        - field_s_visitor_position_title
+        - field_s_visitor_curr_inst
+        - field_s_visitor_year_visited
+        - field_s_visitor_research_area
+      below_break:
+        - body
+        - field_s_visitor_donor
+        - field_s_visitor_external_link
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 1
+        label: hidden
+        formatter: default
+        settings:
+          wrapper: h1
+          class: ''
+          link: false
+_core:
+  default_config_hash: gNzzw-gxLhYU8k5kJuePMCvgR3aIqeSDqXtxIIUFhHE
+id: node.stanford_visitor.default
+targetEntityType: node
+bundle: stanford_visitor
 mode: default
 content:
-  description:
-    label: hidden
+  body:
     type: text_default
-    weight: 3
-    region: top
+    weight: 6
+    region: below_break
+    label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_mrc_event_series_image:
-    weight: 2
-    label: hidden
-    settings:
-      image_style: ''
-      image_link: ''
-    third_party_settings: {  }
-    type: image
-    region: top
-  field_mrc_event_series_name:
-    weight: 1
+  field_s_visitor_curr_inst:
+    type: string
+    weight: 3
+    region: above_break
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_s_visitor_donor:
     type: string
-    region: top
-hidden: {  }
+    weight: 7
+    region: below_break
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_s_visitor_external_link:
+    type: link
+    weight: 8
+    region: below_break
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  field_s_visitor_photo:
+    type: image
+    weight: 0
+    region: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    third_party_settings: {  }
+  field_s_visitor_position_title:
+    type: string
+    weight: 2
+    region: above_break
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_s_visitor_research_area:
+    type: entity_reference_label
+    weight: 5
+    region: above_break
+    label: inline
+    settings:
+      link: false
+    third_party_settings:
+      ds:
+        ds_limit: ''
+  field_s_visitor_year_visited:
+    type: yearonly_academic
+    weight: 4
+    region: above_break
+    label: inline
+    settings:
+      order: asc
+    third_party_settings:
+      ds:
+        ds_limit: ''
+hidden:
+  field_mrc_event_series: true
+  field_s_visitor_first_name: true
+  field_s_visitor_last_name: true
+  links: true

--- a/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
+++ b/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
@@ -2,30 +2,88 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.stanford_visitor.body
-    - field.field.node.stanford_visitor.field_mrc_event_series
-    - field.field.node.stanford_visitor.field_s_visitor_curr_inst
-    - field.field.node.stanford_visitor.field_s_visitor_donor
-    - field.field.node.stanford_visitor.field_s_visitor_external_link
-    - field.field.node.stanford_visitor.field_s_visitor_first_name
-    - field.field.node.stanford_visitor.field_s_visitor_last_name
-    - field.field.node.stanford_visitor.field_s_visitor_photo
-    - field.field.node.stanford_visitor.field_s_visitor_position_title
-    - field.field.node.stanford_visitor.field_s_visitor_research_area
-    - field.field.node.stanford_visitor.field_s_visitor_year_visited
-    - image.style.medium
-    - node.type.stanford_visitor
+    - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_image
+    - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_name
+    - taxonomy.vocabulary.mrc_event_series
   module:
     - ds
     - image
-    - link
-    - mrc_yearonly
+    - mrc_ds_blocks
     - text
-    - user
 third_party_settings:
+  mrc_ds_blocks:
+    'views_block:mrc_events-event_series_past_events':
+      config:
+        provider: views
+        admin_label: ''
+        label: ''
+        label_display: visible
+        field_mrc_event_series_target_id: ''
+        items_per_page: none
+        views_label_checkbox: 0
+        views_label: ''
+      parent_name: ''
+      weight: 5
+      region: bottom_left
+    'views_block:mrc_events-event_series_upcoming_events':
+      config:
+        provider: views
+        admin_label: ''
+        label: ''
+        label_display: visible
+        field_mrc_event_series_target_id: ''
+        items_per_page: none
+        views_label_checkbox: 0
+        views_label: ''
+      parent_name: ''
+      weight: 4
+      region: sidebar
+    'views_block:mrc_news-event_series_related_news':
+      config:
+        provider: views
+        admin_label: ''
+        label: ''
+        label_display: visible
+        field_mrc_event_series_target_id: ''
+        items_per_page: none
+        views_label_checkbox: 0
+        views_label: ''
+      parent_name: ''
+      weight: 6
+      region: bottom_right
+    'views_block:mrc_visitor-event_series_visitors':
+      config:
+        provider: views
+        admin_label: ''
+        label: ''
+        label_display: visible
+        field_mrc_event_series_target_id: ''
+        items_per_page: none
+        views_label_checkbox: 0
+        views_label: ''
+      parent_name: ''
+      weight: 7
+      region: footer
+    'menu_block:main':
+      config:
+        provider: menu_block
+        admin_label: ''
+        label: 'Main navigation'
+        label_display: visible
+        level: '1'
+        depth: '0'
+        expand: 1
+        parent: 'main:'
+        label_type: root
+        follow: 1
+        follow_parent: '0'
+        suggestion: main
+      parent_name: ''
+      weight: 0
+      region: sidebar
   ds:
     layout:
-      id: pattern_node_simple
+      id: pattern_terms_event_series
       library: null
       disable_css: false
       entity_classes: all_classes
@@ -33,109 +91,46 @@ third_party_settings:
         pattern:
           field_templates: default
     regions:
-      image:
-        - field_s_visitor_photo
-      above_break:
-        - node_title
-        - field_s_visitor_position_title
-        - field_s_visitor_curr_inst
-        - field_s_visitor_year_visited
-        - field_s_visitor_research_area
-      below_break:
-        - body
-        - field_s_visitor_donor
-        - field_s_visitor_external_link
-    fields:
-      node_title:
-        plugin_id: node_title
-        weight: 1
-        label: hidden
-        formatter: default
-        settings:
-          wrapper: h1
-          class: ''
-          link: false
-_core:
-  default_config_hash: gNzzw-gxLhYU8k5kJuePMCvgR3aIqeSDqXtxIIUFhHE
-id: node.stanford_visitor.default
-targetEntityType: node
-bundle: stanford_visitor
+      sidebar:
+        - 'menu_block:main'
+        - 'views_block:mrc_events-event_series_upcoming_events'
+      top:
+        - field_mrc_event_series_name
+        - field_mrc_event_series_image
+        - description
+      bottom_left:
+        - 'views_block:mrc_events-event_series_past_events'
+      bottom_right:
+        - 'views_block:mrc_news-event_series_related_news'
+      footer:
+        - 'views_block:mrc_visitor-event_series_visitors'
+id: taxonomy_term.mrc_event_series.default
+targetEntityType: taxonomy_term
+bundle: mrc_event_series
 mode: default
 content:
-  body:
-    type: text_default
-    weight: 6
-    region: below_break
+  description:
     label: hidden
+    type: text_default
+    weight: 3
+    region: top
     settings: {  }
     third_party_settings: {  }
-  field_s_visitor_curr_inst:
-    type: string
-    weight: 3
-    region: above_break
+  field_mrc_event_series_image:
+    weight: 2
     label: hidden
     settings:
-      link_to_entity: false
-    third_party_settings: {  }
-  field_s_visitor_donor:
-    type: string
-    weight: 7
-    region: below_break
-    label: inline
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-  field_s_visitor_external_link:
-    type: link
-    weight: 8
-    region: below_break
-    label: inline
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-  field_s_visitor_photo:
-    type: image
-    weight: 0
-    region: image
-    label: hidden
-    settings:
-      image_style: medium
+      image_style: ''
       image_link: ''
     third_party_settings: {  }
-  field_s_visitor_position_title:
-    type: string
-    weight: 2
-    region: above_break
+    type: image
+    region: top
+  field_mrc_event_series_name:
+    weight: 1
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_s_visitor_research_area:
-    type: entity_reference_label
-    weight: 5
-    region: above_break
-    label: inline
-    settings:
-      link: false
-    third_party_settings:
-      ds:
-        ds_limit: ''
-  field_s_visitor_year_visited:
-    type: yearonly_academic
-    weight: 4
-    region: above_break
-    label: inline
-    settings:
-      order: asc
-    third_party_settings:
-      ds:
-        ds_limit: ''
-hidden:
-  field_mrc_event_series: true
-  field_s_visitor_first_name: true
-  field_s_visitor_last_name: true
-  links: true
+    type: string
+    region: top
+hidden: {  }

--- a/modules/mrc_visitor/config/install/views.view.mrc_visitor.yml
+++ b/modules/mrc_visitor/config/install/views.view.mrc_visitor.yml
@@ -67,9 +67,8 @@ display:
         type: default
         options:
           grouping: {  }
-          row_class: ''
+          row_class: decanter-width-one-third
           default_row_class: true
-          uses_fields: false
       row:
         type: ui_patterns
         options:
@@ -423,7 +422,7 @@ display:
       use_more: true
       use_more_always: false
       use_more_text: 'See all visitors'
-      link_url: 'visitors?series={{ raw_arguments.field_mrc_event_series_target_id }}'
+      link_url: 'visitors?series[]={{ raw_arguments.tid }}'
       link_display: custom_url
     cache_metadata:
       max-age: 0
@@ -934,7 +933,7 @@ display:
             description: ''
             use_operator: false
             operator: field_mrc_event_series_target_id_op
-            identifier: event_series
+            identifier: series
             required: false
             remember: false
             multiple: true
@@ -942,6 +941,7 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+              site_owner: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -1067,6 +1067,7 @@ display:
             value: 'No visitors match your search. Please try again.'
             format: basic_html
           plugin_id: text
+      exposed_block: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1094,6 +1095,68 @@ display:
       title: Visitors
       defaults:
         title: false
+        relationships: false
+        arguments: false
+      relationships:
+        term_node_tid:
+          id: term_node_tid
+          table: node_field_data
+          field: term_node_tid
+          relationship: none
+          group_type: group
+          admin_label: term
+          required: true
+          vids:
+            - mrc_event_series
+          entity_type: node
+          plugin_id: node_term_data
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.tid }} Visitors'
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            anyall: ','
+            node: false
+            limit: false
+            vids: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              mrc_event_series: mrc_event_series
+            operation: view
+            multiple: 0
+            access: false
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
     cache_metadata:
       max-age: 0
       contexts:

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -16,8 +16,20 @@ function stanford_mrc_post_update_8_0_4() {
  * Release 8.0.5 changes.
  */
 function stanford_mrc_post_update_8_0_5() {
-  // Load videos list view.
   module_load_install('stanford_mrc');
-  $path = drupal_get_path('module', 'mrc_events') . '/config/install';
-  stanford_mrc_update_configs(TRUE, ['views.view.mrc_videos'], $path);
+
+  $configs = [
+    'mrc_events' => ['views.view.mrc_videos'],
+    'mrc_helper' => ['core.entity_view_display.taxonomy_term.mrc_event_series.default'],
+    'mrc_news' => [
+      'core.entity_form_display.node.stanford_news_item.default',
+      'views.view.mrc_news',
+    ],
+    'mrc_visitor' => ['views.view.mrc_visitor'],
+  ];
+
+  foreach ($configs as $module => $config) {
+    $path = drupal_get_path('module', $module) . '/config/install';
+    stanford_mrc_update_configs(TRUE, $config, $path);
+  }
 }

--- a/themes/math_research_center/math_research_center.theme
+++ b/themes/math_research_center/math_research_center.theme
@@ -34,6 +34,16 @@ function math_research_center_preprocess(&$variables, $hook) {
 }
 
 /**
+ * Implements hook_preprocess_views_view().
+ */
+function math_research_center_preprocess_views_view(&$vars) {
+  if (!empty($vars['more'])) {
+    // Add class to read more link in views.
+    $vars['more']['#options']['attributes']['class'][] = 'decanter-button';
+  }
+}
+
+/**
  * Helper function to preprocess all patterns.
  */
 function math_research_center_preprocess_pattern(&$variables, $hook) {

--- a/themes/math_research_center/templates/views/views-view.html.twig
+++ b/themes/math_research_center/templates/views/views-view.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Theme override for main view template.
+ *
+ * Available variables:
+ * - attributes: Remaining HTML attributes for the element.
+ * - css_name: A css-safe version of the view name.
+ * - css_class: The user-specified classes names, if any.
+ * - header: The optional header.
+ * - footer: The optional footer.
+ * - rows: The results of the view query, if any.
+ * - empty: The content to display if there are no rows.
+ * - pager: The optional pager next/prev links to display.
+ * - exposed: Exposed widget form/info to display.
+ * - feed_icons: Optional feed icons to display.
+ * - more: An optional link to the next page of results.
+ * - title: Title of the view, only used when displaying in the admin preview.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the view title.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the view title.
+ * - attachment_before: An optional attachment view to be displayed before the
+ *   view content.
+ * - attachment_after: An optional attachment view to be displayed after the
+ *   view content.
+ * - dom_id: Unique id for every view being printed to give unique class for
+ *   Javascript.
+ *
+ * @see template_preprocess_views_view()
+ */
+#}
+{%
+  set classes = [
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {{ title }}
+  {{ title_suffix }}
+
+  {% if header %}
+    <header>
+      {{ header }}
+    </header>
+  {% endif %}
+
+  {{ exposed }}
+  {{ attachment_before }}
+
+  {% if rows %}
+    <div class="rows">
+      {{ rows }}
+    </div>
+  {% endif %}
+  {{ empty }}
+  {{ pager }}
+
+  {{ attachment_after }}
+  {{ more }}
+
+  {% if footer %}
+    <footer>
+      {{ footer }}
+    </footer>
+  {% endif %}
+
+  {{ feed_icons }}
+</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the exposed filters
- Changed the titles on the event series blocks dynamically
- Changed order of blocks on term pages
- Added class to read more button
- Wrapped view rows in a div to fix `decanter-width-*` classes on view rows

# Needed By (Date)
- end of sprint

# Urgency
- High

# Steps to Test

1. a patch was applied on core so ensure you have pull and do latest composer update
2. sync from production
3. update database
4. optionally enable devel_generate and create lots of events, news and visitors
5. view the event series pages and ensure the changes in the summary above are visible.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)