### PR TITLE
MRCD8-235: image not required for visitor and file dir change

### DIFF
--- a/modules/mrc_visitor/config/install/field.field.node.stanford_visitor.field_s_visitor_photo.yml
+++ b/modules/mrc_visitor/config/install/field.field.node.stanford_visitor.field_s_visitor_photo.yml
@@ -12,12 +12,12 @@ entity_type: node
 bundle: stanford_visitor
 label: Photo
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: media/image
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -25,7 +25,10 @@ function stanford_mrc_post_update_8_0_5() {
       'core.entity_form_display.node.stanford_news_item.default',
       'views.view.mrc_news',
     ],
-    'mrc_visitor' => ['views.view.mrc_visitor'],
+    'mrc_visitor' => [
+      'views.view.mrc_visitor',
+      'field.field.node.stanford_visitor.field_s_visitor_photo.yml'
+    ],
     'mrc_paragraphs_slide' => ['core.entity_view_display.paragraph.mrc_slide.default'],
   ];
 

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -27,7 +27,7 @@ function stanford_mrc_post_update_8_0_5() {
     ],
     'mrc_visitor' => [
       'views.view.mrc_visitor',
-      'field.field.node.stanford_visitor.field_s_visitor_photo.yml'
+      'field.field.node.stanford_visitor.field_s_visitor_photo.yml',
     ],
     'mrc_paragraphs_slide' => ['core.entity_view_display.paragraph.mrc_slide.default'],
   ];

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -27,7 +27,7 @@ function stanford_mrc_post_update_8_0_5() {
     ],
     'mrc_visitor' => [
       'views.view.mrc_visitor',
-      'field.field.node.stanford_visitor.field_s_visitor_photo.yml',
+      'field.field.node.stanford_visitor.field_s_visitor_photo',
     ],
     'mrc_paragraphs_slide' => ['core.entity_view_display.paragraph.mrc_slide.default'],
   ];


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- visitor image not required and file dir change

# Needed By (Date)
- end of sprint

# Urgency
- low

# Steps to Test

1. sync db with prod
2. checkout this branch and run updb
3. verify that the photo in the visitor content type is not required and has the path media/image

# Affected Projects or Products
- MRC

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/MRCD8-235
