### PR TITLE
Mrcd8 288 taxonomy links

### DIFF
--- a/modules/mrc_helper/config/install/core.entity_form_display.taxonomy_term.mrc_event_series.default.yml
+++ b/modules/mrc_helper/config/install/core.entity_form_display.taxonomy_term.mrc_event_series.default.yml
@@ -2,12 +2,13 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_image
+    - entity_browser.browser.image_browser
     - field.field.taxonomy_term.mrc_event_series.field_mrc_event_series_name
-    - image.style.thumbnail
+    - field.field.taxonomy_term.mrc_event_series.field_mrc_image
     - taxonomy.vocabulary.mrc_event_series
   module:
-    - image
+    - entity_browser
+    - path
     - text
 id: taxonomy_term.mrc_event_series.default
 targetEntityType: taxonomy_term
@@ -30,14 +31,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  name:
-    type: string_textfield
-    weight: 1
-    region: content
-    settings:
-      size: 60
-      placeholder: Shortname
-    third_party_settings: {  }
   field_mrc_image:
     type: entity_browser_entity_reference
     weight: 2
@@ -52,5 +45,20 @@ content:
       field_widget_display_settings:
         view_mode: thumbnail
       field_widget_edit: true
+      field_widget_replace: false
+  name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: Shortname
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
-  path: true
+  field_mrc_event_series_image: true

--- a/modules/mrc_helper/mrc_helper.post_update.php
+++ b/modules/mrc_helper/mrc_helper.post_update.php
@@ -32,6 +32,7 @@ function mrc_helper_post_update_8_0_6() {
  * Change menu links to entity reference links.
  */
 function mrc_helper_post_update_8_0_7() {
+  \Drupal::service('module_installer')->install(['taxonomy_menu_ui']);
   $database = \Drupal::database();
   $links = $database->select('menu_link_content_data', 'm')
     ->fields('m', ['id', 'link__uri'])

--- a/modules/mrc_helper/mrc_helper.post_update.php
+++ b/modules/mrc_helper/mrc_helper.post_update.php
@@ -27,3 +27,38 @@ function mrc_helper_post_update_8_0_6() {
   $config_update = \Drupal::service('config_update.config_update');
   $config_update->import('view', 'mrc_event_series');
 }
+
+/**
+ * Change menu links to entity reference links.
+ */
+function mrc_helper_post_update_8_0_7() {
+  $database = \Drupal::database();
+  $links = $database->select('menu_link_content_data', 'm')
+    ->fields('m', ['id', 'link__uri'])
+    ->condition('link__uri', 'internal:%', 'LIKE')
+    ->execute()
+    ->fetchAllKeyed();
+  foreach ($links as $id => $link) {
+    $link = str_replace('internal:', '', $link);
+
+    $source = $database->select('url_alias', 'u')
+      ->fields('u', ['source'])
+      ->condition('alias', $link)
+      ->execute()
+      ->fetchField();
+
+    $source = trim($source, '/ ');
+    list(, $type, $entity_id) = explode('/', $source);
+    if ($type == 'term') {
+      $new_link = "entity:taxonomy_term/$entity_id";
+      $database->update('menu_link_content_data')
+        ->fields(['link__uri' => $new_link])
+        ->condition('id', $id)
+        ->execute();
+    }
+  }
+
+  /** @var \Drupal\config_update\ConfigReverter $config_update */
+  $config_update = \Drupal::service('config_update.config_update');
+  $config_update->revert('entity_form_display', 'taxonomy_term.mrc_event_series.default');
+}

--- a/modules/mrc_helper/mrc_helper.routing.yml
+++ b/modules/mrc_helper/mrc_helper.routing.yml
@@ -1,0 +1,6 @@
+mrc_helper:
+  path: '/dynamic_reference_autocomplete/{selection_settings_key}'
+  defaults:
+    _controller: '\Drupal\mrc_helper\Controller\DynamicEntityAutocompleteController::handleAutocomplete'
+  requirements:
+    _access: 'TRUE'

--- a/modules/mrc_helper/src/Controller/DynamicEntityAutocompleteController.php
+++ b/modules/mrc_helper/src/Controller/DynamicEntityAutocompleteController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\mrc_helper\Controller;
+
+use Drupal\Component\Utility\Tags;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityAutocompleteMatcher;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Controller to handle dynamic entity autocomplete.
+ */
+class DynamicEntityAutocompleteController extends ControllerBase {
+
+  /**
+   * The autocomplete matcher for entity references.
+   *
+   * @var \Drupal\Core\Entity\EntityAutocompleteMatcher
+   */
+  protected $matcher;
+
+  /**
+   * The key value store.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
+   */
+  protected $keyValue;
+
+  /**
+   * Constructs a EntityAutocompleteController object.
+   *
+   * @param \Drupal\Core\Entity\EntityAutocompleteMatcher $matcher
+   *   The autocomplete matcher for entity references.
+   * @param \Drupal\Core\KeyValueStore\KeyValueStoreInterface $key_value
+   *   The key value factory.
+   */
+  public function __construct(EntityAutocompleteMatcher $matcher, KeyValueStoreInterface $key_value) {
+    $this->matcher = $matcher;
+    $this->keyValue = $key_value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.autocomplete_matcher'),
+      $container->get('keyvalue')->get('dynamic_entity_autocomplete')
+    );
+  }
+
+  /**
+   * Handle the dymamic autocomplete route.
+   */
+  public function handleAutocomplete(Request $request, $selection_settings_key) {
+    if (!$input = $request->query->get('q')) {
+      throw new \Exception('No input given to autocomplete route.');
+    }
+
+    $typed_string = Tags::explode($input);
+    $typed_string = Unicode::strtolower(array_pop($typed_string));
+    $selection_settings = $this->keyValue->get($selection_settings_key, FALSE);
+
+    $combined_matches = [];
+
+    foreach ($selection_settings as $entity_type_id => $settings) {
+      $matches = $this->matcher->getMatches($entity_type_id, $settings['selection_handler'], $settings['selection_settings'], $typed_string);
+      foreach ($matches as $match) {
+        preg_match('/(?<entity_id>\d+)\)$/', $match['value'], $matches);
+        $combined_matches[] = [
+          'label' => $match['label'],
+          'value' => sprintf('%s (%s:%s)', $match['label'], $entity_type_id, $matches['entity_id']),
+        ];
+      }
+    }
+
+    return new JsonResponse($combined_matches);
+  }
+
+}

--- a/modules/mrc_helper/src/Element/DynamicEntityAutocomplete.php
+++ b/modules/mrc_helper/src/Element/DynamicEntityAutocomplete.php
@@ -15,7 +15,8 @@ use Drupal\Core\Site\Settings;
  * Provides a "dynamic" entity autocomplete form element.
  *
  * This form element allows you to create an entity autocomplete that works
- * with multiple types of entities.
+ * with multiple types of entities. This wont be needed when
+ * https://www.drupal.org/project/drupal/issues/2423093 is resolved.
  *
  * @see \Drupal\Core\Entity\Element\EntityAutocomplete
  *

--- a/modules/mrc_helper/src/Element/DynamicEntityAutocomplete.php
+++ b/modules/mrc_helper/src/Element/DynamicEntityAutocomplete.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\mrc_helper\Element;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\Component\Utility\Tags;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
+use Drupal\Core\Render\Element\Textfield;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Provides a "dynamic" entity autocomplete form element.
+ *
+ * This form element allows you to create an entity autocomplete that works
+ * with multiple types of entities.
+ *
+ * @see \Drupal\Core\Entity\Element\EntityAutocomplete
+ *
+ * @FormElement("dynamic_entity_autocomplete")
+ */
+class DynamicEntityAutocomplete extends Textfield {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $info = parent::getInfo();
+    $class = get_class($this);
+
+    // An array keyed in the format of:
+    // entity_type_id:
+    //   selection_settings:
+    //     ...selection settings
+    //   selection_handler: handler
+    $info['#target_types'] = NULL;
+
+    array_unshift($info['#process'], [$class, 'processDynamicEntityAutocomplete']);
+    $info['#element_validate'] = [[$class, 'validateDynamicEntityAutocomplete']];
+    return $info;
+  }
+
+  /**
+   * Process the dyanmic_entity_autocomplete widget.
+   */
+  public static function processDynamicEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    if (empty($element['#target_types'])) {
+      throw new \InvalidArgumentException('Missing required #target_types parameter.');
+    }
+    // Serialize all of the settings for this element into state, so the route
+    // can pull it back out. See EntityAutocomplete for details on this
+    // approach.
+    $autocomplete_data = serialize($element['#target_types']);
+    $selection_settings_key = Crypt::hmacBase64($autocomplete_data, Settings::getHashSalt());
+    $key_value_storage = static::getEntityAutocompleteKeyValueStore();
+    if (!$key_value_storage->has($selection_settings_key)) {
+      $key_value_storage->set($selection_settings_key, $element['#target_types']);
+    }
+    $element['#autocomplete_route_name'] = 'mrc_helper';
+    $element['#autocomplete_route_parameters'] = [
+      'selection_settings_key' => $selection_settings_key,
+    ];
+    return $element;
+  }
+
+  /**
+   * Validate the dynamic_auto_complete element.
+   */
+  public static function validateDynamicEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    // If the value is already an array, it may have been set as #value,
+    // and thus should already be in the correct format.
+    if (is_array($element['#value'])) {
+      $form_state->setValueForElement($element, $element['#value']);
+      return;
+    }
+
+    $element_value = [];
+    $entity_ids_from_input = static::getEntityIdsByEntityTypeFromInput($element['#value']);
+
+    foreach ($element['#target_types'] as $entity_type_id => $settings) {
+      $options = [
+        'target_type' => $entity_type_id,
+        'handler' => $settings['selection_handler'],
+        'handler_settings' => $settings['selection_settings'],
+      ];
+      // Validate all entities selected for the specific entity type.
+      $handler = static::getSelectionManager()->getInstance($options);
+      if (isset($entity_ids_from_input[$entity_type_id])) {
+        $valid_ids = $handler->validateReferenceableEntities($entity_ids_from_input[$entity_type_id]);
+        if ($invalid_ids = array_diff($entity_ids_from_input[$entity_type_id], $valid_ids)) {
+          foreach ($invalid_ids as $invalid_id) {
+            $form_state->setError($element, t('The referenced entity (%type: %id) does not exist.', ['%type' => $entity_type_id, '%id' => $invalid_id]));
+          }
+        }
+        foreach ($valid_ids as $valid_entity_id) {
+          $element_value[] = [
+            'entity' => static::loadEntity($entity_type_id, $valid_entity_id)
+          ];
+        }
+      }
+    }
+    $form_state->setValueForElement($element, $element_value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+    // If the default value is set to an array of entities, create a string
+    // for it.
+    if ($input === FALSE && isset($element['#default_value']) && is_array($element['#default_value'])) {
+      return static::getEntityLabels($element['#default_value']);
+    }
+  }
+
+  /**
+   * Converts an array of entity objects into a string of entity labels.
+   *
+   * This method is also responsible for checking the 'view label' access on the
+   * passed-in entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface[] $entities
+   *   An array of entity objects.
+   *
+   * @return string
+   *   A string of entity labels separated by commas.
+   */
+  public static function getEntityLabels(array $entities) {
+    $entity_labels = [];
+    foreach ($entities as $entity) {
+      $label = ($entity->access('view label')) ? $entity->label() : t('- Restricted access -');
+      $entity_labels[] = Tags::encode(sprintf('%s (%s:%s)', $label, $entity->getEntityTypeId(), $entity->id()));
+    }
+    return implode(', ', $entity_labels);
+  }
+
+  /**
+   * Get the entity type IDs from some input.
+   *
+   * @param string $input
+   *   The input.
+   * @return array
+   */
+  public static function getEntityIdsByEntityTypeFromInput($input) {
+    $tags = Tags::explode($input);
+    $entities = [];
+    foreach ($tags as $tag) {
+      preg_match('/(?<type>\w+)\:(?<id>\d+)\)$/', $tag, $matches);
+      if (!empty($matches['type']) && !empty($matches['id'])) {
+        $entities[$matches['type']][] = $matches['id'];
+      }
+    }
+    return $entities;
+  }
+
+  /**
+   * Get the selection plugin manager.
+   *
+   * @return SelectionPluginManagerInterface
+   *   The selection plugin manager.
+   */
+  protected static function getSelectionManager() {
+    return \Drupal::service('plugin.manager.entity_reference_selection');
+  }
+
+  /**
+   * Load an entity.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string $entity_id
+   *   The entity id.
+   *
+   * @return EntityInterface
+   *   A loaded entity.
+   */
+  protected static function loadEntity($entity_type_id, $entity_id) {
+    return \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
+  }
+
+  /**
+   * Get the entity autocomplete key/value store.
+   *
+   * @return KeyValueStoreInterface
+   *   The key/value store.
+   */
+  protected static function getEntityAutocompleteKeyValueStore() {
+    return \Drupal::keyValue('dynamic_entity_autocomplete');
+  }
+
+}

--- a/modules/mrc_helper/src/Plugin/Field/FieldWidget/LinkFieldWidget.php
+++ b/modules/mrc_helper/src/Plugin/Field/FieldWidget/LinkFieldWidget.php
@@ -9,7 +9,9 @@ use Drupal\link\Plugin\Field\FieldWidget\LinkWidget;
 use Drupal\mrc_helper\Element\DynamicEntityAutocomplete;
 
 /**
- * Plugin implementation of the 'link' widget.
+ * Overrides the default core link widget.
+ *
+ * Remove when https://www.drupal.org/project/drupal/issues/2423093 is resolved.
  *
  * @FieldWidget(
  *   id = "link_default",

--- a/modules/mrc_helper/src/Plugin/Field/FieldWidget/LinkFieldWidget.php
+++ b/modules/mrc_helper/src/Plugin/Field/FieldWidget/LinkFieldWidget.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\mrc_helper\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\link\Plugin\Field\FieldWidget\LinkWidget;
+use Drupal\mrc_helper\Element\DynamicEntityAutocomplete;
+
+/**
+ * Plugin implementation of the 'link' widget.
+ *
+ * @FieldWidget(
+ *   id = "link_default",
+ *   label = @Translation("Link"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class LinkFieldWidget extends LinkWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    if ($element['uri']['#type'] != 'entity_autocomplete') {
+      return $element;
+    }
+
+    $element['uri']['#type'] = 'dynamic_entity_autocomplete';
+
+    $target_types = [
+      'node' => [
+        'selection_handler' => 'default',
+        'selection_settings' => [],
+      ],
+      'taxonomy_term' => [
+        'selection_handler' => 'default',
+        'selection_settings' => [],
+      ],
+    ];
+    $element['uri']['#target_types'] = $target_types;
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function getUserEnteredStringAsUri($string) {
+    // By default, assume the entered string is an URI.
+    $uri = $string;
+    // Detect entity autocomplete string, map to 'entity:' URI.
+    $entity = EntityAutocomplete::extractEntityIdFromAutocompleteInput($string);
+
+    if ($entity !== NULL && strpos($entity, ':') !== FALSE) {
+      list($entity_type, $entity_id) = explode(':', $entity);
+      $uri = "entity:$entity_type/$entity_id";
+    }
+    // Detect a schemeless string, map to 'internal:' URI.
+    elseif (!empty($string) && parse_url($string, PHP_URL_SCHEME) === NULL) {
+      // @todo '<front>' is valid input for BC reasons, may be removed by
+      //   https://www.drupal.org/node/2421941
+      // - '<front>' -> '/'
+      // - '<front>#foo' -> '/#foo'
+      if (strpos($string, '<front>') === 0) {
+        $string = '/' . substr($string, strlen('<front>'));
+      }
+      $uri = 'internal:' . $string;
+    }
+    return $uri;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function getUriAsDisplayableString($uri) {
+    $scheme = parse_url($uri, PHP_URL_SCHEME);
+
+    // By default, the displayable string is the URI.
+    $displayable_string = $uri;
+
+    // A different displayable string may be chosen in case of the 'internal:'
+    // or 'entity:' built-in schemes.
+    if ($scheme === 'internal') {
+      $uri_reference = explode(':', $uri, 2)[1];
+
+      $path = parse_url($uri, PHP_URL_PATH);
+      if ($path === '/') {
+        $uri_reference = '<front>' . substr($uri_reference, 1);
+      }
+
+      $displayable_string = $uri_reference;
+    }
+    elseif ($scheme === 'entity') {
+      list($entity_type, $entity_id) = explode('/', substr($uri, 7), 2);
+
+      if (in_array($entity_type, [
+          'node',
+          'taxonomy_term',
+        ]) && $entity = \Drupal::entityTypeManager()
+          ->getStorage($entity_type)
+          ->load($entity_id)) {
+        $displayable_string = DynamicEntityAutocomplete::getEntityLabels([$entity]);
+      }
+    }
+
+    return $displayable_string;
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- Override link fields to use a dynamic entity reference.
- Allow taxonomy terms to link in the menu from the term form like nodes.

# Needed By (Date)
- End of sprint

# Urgency
- Medium

# Steps to Test
1. Pull latest BLT and composer update
2. sync to production & update database
3. edit one of the event series terms.
4. ensure the menu settings exist and are configured as expected
5. create a new basic page, news or event.. any node that has a link field that will display on the node display
6. in the link field, start typing one of the taxonomy terms.
7. verify it suggests a taxonomy term and that you can save correctly.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)