### PR TITLE
MRCD8-318 Enable module and re-index for partial searches

### DIFF
--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -426,6 +426,13 @@ function stanford_mrc_post_update_8_0_7() {
  * Release 8.0.8 Changes.
  */
 function stanford_mrc_post_update_8_0_8() {
+  \Drupal::service('module_installer')->install(['porterstemmer']);
+  // Mark site for re-indexing.
+  $search_page_repository = \Drupal::service('search.search_page_repository');
+  foreach ($search_page_repository->getIndexableSearchPages() as $entity) {
+    $entity->getPlugin()->markForReindex();
+  }
+
   /** @var \Drupal\config_update\ConfigReverter $config_update */
   $config_update = \Drupal::service('config_update.config_update');
 //  $config_update->revert('node_type', 'stanford_event');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable porterstemmer module and mark nodes for re-indexing
- porterstemmer: The process of stemming reduces each word in the search index to its basic root or stem (e.g. 'blogging' to 'blog') so that variations on a word ('blogs', 'blogger', 'blogging', 'blog') are considered equivalent when searching. This generally results in more relevant search results.

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test
0. if https://github.com/SU-HSDO/mrc_blt/pull/14 isn't merged, checkout that branch and composer update/install.
1. sync to prod
2. Checkout branch
3. update database
4. run cron until all nodes are indexed. it took me 2 cron runs
5. search the site for art historian and validate `art historians` is a result.
6. test out other works like `recipient` etc

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)