### PR TITLE
MRCD8-324 video list styles

### DIFF
--- a/themes/math_research_center/patterns/molecules/video-list/css/video-list.css
+++ b/themes/math_research_center/patterns/molecules/video-list/css/video-list.css
@@ -1,2 +1,3 @@
+.mrc-video-list__video .video-embed-field-lazy img{object-fit:cover}@media (min-width: 482px) and (max-width: 619px){.mrc-video-list__video .video-embed-field-lazy img{height:315px}}@media (min-width: 620px) and (max-width: 899px){.mrc-video-list__video .video-embed-field-lazy img{height:470px}}@media (min-width: 900px) and (max-width: 1200px){.mrc-video-list__video .video-embed-field-lazy img{height:585px}}@media screen and (min-width: 1201px){.mrc-video-list__video .video-embed-field-lazy img{height:655px}}
 
 /*# sourceMappingURL=video-list.css.map */

--- a/themes/math_research_center/patterns/molecules/video-list/scss/video-list.scss
+++ b/themes/math_research_center/patterns/molecules/video-list/scss/video-list.scss
@@ -11,3 +11,25 @@
 // Stanford Math Research Center
 @import
   '../utilities/mixins/mixins';
+
+.mrc-video-list__video {
+  .video-embed-field-lazy img {
+    object-fit: cover;
+
+    @media (min-width: 482px) and (max-width: 619px) {
+      height: 315px;
+    }
+
+    @media (min-width: 620px) and (max-width: 899px) {
+      height: 470px;
+    }
+
+    @media (min-width: 900px) and (max-width: 1200px) {
+      height: 585px;
+    }
+
+    @include media($large-screen) {
+      height: 655px;
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added breakpoints and styled lazy images so that there is not a jump between image and video playing
- At mobile breakpoint, default behavior occurs (don't want to hard code mobile or below)
- Left decanter embed container

# Needed By (Date)
- End of sprint (3/29)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Verify that the images are taller but not distorted

# Affected Projects or Products
- MRC
- stanford_mrc

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/MRCD8-324

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)