### PR TITLE
ARCH-21 Switched from mrc_media to stanford_media

### DIFF
--- a/modules/mrc_events/config/install/core.entity_view_display.node.stanford_event.default.yml
+++ b/modules/mrc_events/config/install/core.entity_view_display.node.stanford_event.default.yml
@@ -27,7 +27,7 @@ dependencies:
     - link
     - mrc_date
     - mrc_ds_blocks
-    - mrc_media
+    - stanford_media
     - telephone
     - text
     - user

--- a/modules/mrc_events/config/install/views.view.mrc_events.yml
+++ b/modules/mrc_events/config/install/views.view.mrc_events.yml
@@ -16,7 +16,7 @@ dependencies:
     - datetime
     - datetime_range
     - mrc_date
-    - mrc_media
+    - stanford_media
     - node
     - taxonomy
     - text

--- a/modules/mrc_helper/config/install/views.view.mrc_event_series.yml
+++ b/modules/mrc_helper/config/install/views.view.mrc_event_series.yml
@@ -5,7 +5,7 @@ dependencies:
     - field.storage.taxonomy_term.field_mrc_image
     - taxonomy.vocabulary.mrc_event_series
   module:
-    - mrc_media
+    - stanford_media
     - taxonomy
     - text
     - ui_patterns_views

--- a/modules/mrc_media/config/install/entity_browser.browser.file_browser.yml
+++ b/modules/mrc_media/config/install/entity_browser.browser.file_browser.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - views.view.media_entity_browser
   module:
-    - mrc_media
+    - stanford_media
     - views
 name: file_browser
 label: 'File Browser'

--- a/modules/mrc_media/config/install/entity_browser.browser.image_browser.yml
+++ b/modules/mrc_media/config/install/entity_browser.browser.image_browser.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - views.view.media_entity_browser
   module:
-    - mrc_media
+    - stanford_media
     - views
 name: image_browser
 label: 'Image Browser'

--- a/modules/mrc_media/config/install/entity_browser.browser.media_browser.yml
+++ b/modules/mrc_media/config/install/entity_browser.browser.media_browser.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - views.view.media_entity_browser
   module:
-    - mrc_media
+    - stanford_media
     - views
 name: media_browser
 label: 'Media Browser'

--- a/modules/mrc_media/config/install/entity_browser.browser.video_browser.yml
+++ b/modules/mrc_media/config/install/entity_browser.browser.video_browser.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - views.view.media_entity_browser
   module:
-    - mrc_media
+    - stanford_media
     - views
 name: video_browser
 label: 'Video Browser'

--- a/modules/mrc_media/config/install/views.view.media_entity_browser.yml
+++ b/modules/mrc_media/config/install/views.view.media_entity_browser.yml
@@ -10,7 +10,7 @@ dependencies:
     - entity_browser
     - entity_usage
     - media
-    - mrc_media
+    - stanford_media
     - user
 _core:
   default_config_hash: hnzT7Mwai0CQ2L0lo1ey53Qc97VU0vVqyREDBoP1lT4

--- a/modules/mrc_news/config/install/core.entity_view_display.node.stanford_news_item.default.yml
+++ b/modules/mrc_news/config/install/core.entity_view_display.node.stanford_news_item.default.yml
@@ -17,7 +17,7 @@ dependencies:
     - ds
     - link
     - mrc_ds_blocks
-    - mrc_media
+    - stanford_media
     - text
     - user
 third_party_settings:

--- a/modules/mrc_news/config/install/views.view.mrc_news.yml
+++ b/modules/mrc_news/config/install/views.view.mrc_news.yml
@@ -12,7 +12,7 @@ dependencies:
   module:
     - datetime
     - link
-    - mrc_media
+    - stanford_media
     - node
     - taxonomy
     - ui_patterns_views

--- a/modules/mrc_paragraphs_postcard/config/install/core.entity_view_display.paragraph.mrc_postcard.default.yml
+++ b/modules/mrc_paragraphs_postcard/config/install/core.entity_view_display.paragraph.mrc_postcard.default.yml
@@ -11,7 +11,7 @@ dependencies:
   module:
     - ds
     - link
-    - mrc_media
+    - stanford_media
     - text
 third_party_settings:
   ds:

--- a/modules/mrc_paragraphs_postcard/config/install/core.entity_view_display.paragraph.mrc_postcard.mrc_postcard_vertical.yml
+++ b/modules/mrc_paragraphs_postcard/config/install/core.entity_view_display.paragraph.mrc_postcard.mrc_postcard_vertical.yml
@@ -12,7 +12,7 @@ dependencies:
   module:
     - ds
     - link
-    - mrc_media
+    - stanford_media
     - text
 third_party_settings:
   ds:

--- a/modules/mrc_paragraphs_slide/config/install/core.entity_view_display.paragraph.mrc_slide.default.yml
+++ b/modules/mrc_paragraphs_slide/config/install/core.entity_view_display.paragraph.mrc_slide.default.yml
@@ -10,7 +10,7 @@ dependencies:
   module:
     - field_group
     - link
-    - mrc_media
+    - stanford_media
     - text
 third_party_settings:
   field_group:

--- a/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
+++ b/modules/mrc_visitor/config/install/core.entity_view_display.node.stanford_visitor.default.yml
@@ -18,7 +18,7 @@ dependencies:
     - ds
     - link
     - mrc_ds_blocks
-    - mrc_media
+    - stanford_media
     - mrc_yearonly
     - text
     - user

--- a/modules/mrc_visitor/config/install/views.view.mrc_visitor.yml
+++ b/modules/mrc_visitor/config/install/views.view.mrc_visitor.yml
@@ -11,7 +11,7 @@ dependencies:
     - taxonomy.vocabulary.mrc_event_series
     - taxonomy.vocabulary.stanford_mrc_research_area
   module:
-    - mrc_media
+    - stanford_media
     - mrc_yearonly
     - node
     - taxonomy

--- a/stanford_mrc.post_update.php
+++ b/stanford_mrc.post_update.php
@@ -451,3 +451,43 @@ function stanford_mrc_post_update_8_0_8() {
   $config->set('logo.path', 'themes/stanford/stanford_basic/assets/svg/su_logo.svg');
   $config->save();
 }
+
+/**
+ * Switch from mrc_media to stanford_media.
+ */
+function stanford_mrc_post_update_8_0_8__1() {
+  $configs = [
+    'core.entity_view_display.node.stanford_event.default',
+    'core.entity_view_display.node.stanford_news_item.default',
+    'core.entity_view_display.node.stanford_visitor.default',
+    'core.entity_view_display.paragraph.mrc_postcard.default',
+    'core.entity_view_display.paragraph.mrc_postcard.mrc_postcard_vertical',
+    'core.entity_view_display.paragraph.mrc_slide.default',
+    'views.view.media_entity_browser',
+    'views.view.mrc_events',
+    'views.view.mrc_event_series',
+    'views.view.mrc_news',
+    'views.view.mrc_visitor',
+    'entity_browser.browser.media_browser',
+    'entity_browser.browser.file_browser',
+    'entity_browser.browser.image_browser',
+    'entity_browser.browser.video_browser',
+  ];
+  $config_factory = \Drupal::configFactory();
+  foreach ($configs as $config) {
+    $config = $config_factory->getEditable($config);
+    $pos = array_search('mrc_media', $config->get('dependencies.module'));
+    if ($pos !== FALSE) {
+      $config->set("dependencies.module.$pos", 'stanford_media');
+      $config->save();
+    }
+  }
+
+  $config = $config_factory->getEditable('core.extension');
+  $config->set('module.stanford_media', 0);
+  $config->save();
+
+  /** @var \Drupal\Core\Extension\ModuleInstaller $installer */
+  $installer = \Drupal::service('module_installer');
+  $installer->uninstall(['mrc_media']);
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Switch from `mrc_media` to `stanford_media`

# Needed By (Date)
- End of sprint

# Urgency
- High

# Steps to Test

1. Checkout `ARCH-21-abstract-media` branch from [mrc_blt](https://github.com/SU-HSDO/mrc_blt/pull/17)
2. `composer update --prefer-source` and make sure it gets `stanford_media`
3. checkout this branch
4. sync to production
5. update database
6. an extra cache clear might be necessary
7. verify media stuff still works like it did before.

# Associated Issues and/or People
- https://github.com/SU-HSDO/mrc_blt/pull/17

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)